### PR TITLE
Integrations

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -65,6 +65,25 @@
     </dependency>
 
     <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client</artifactId>
+    </dependency>
+
+    <!-- Testing Dependencies -->
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/api/src/main/java/com/redhat/ipaas/api/v1/model/Integration.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/model/Integration.java
@@ -28,6 +28,21 @@ public interface Integration extends WithId<Integration>, WithName, Serializable
 
     String KIND = "integration";
 
+    /**
+     *Required Labels
+     */
+    String LABEL_NAME = "ipaas.redhat.com/integration-name";
+
+    /**
+     * Optional Labels
+     */
+
+    //The integration id
+    String LABEL_ID = "ipaas.redhat.com/integration-id";
+
+    //The integration template id
+    String LABEL_TEMPLATE_ID = "ipaas.redhat.com/template-id";
+
     @Override
     default String kind() {
         return KIND;

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/BaseHandler.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/BaseHandler.java
@@ -17,7 +17,6 @@ package com.redhat.ipaas.api.v1.rest;
 
 import javax.inject.Inject;
 
-import com.redhat.ipaas.api.v1.rest.DataManager;
 
 public class BaseHandler implements WithDataManager {
 

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/DataAccessObject.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/DataAccessObject.java
@@ -1,0 +1,57 @@
+package com.redhat.ipaas.api.v1.rest;
+
+import com.redhat.ipaas.api.v1.model.ListResult;
+import com.redhat.ipaas.api.v1.model.WithId;
+
+public interface DataAccessObject<T extends WithId> {
+
+    /**
+     * @return The Type of entity it supports.
+     */
+    Class<T> getType();
+
+    /**
+     * Fetches an entity by id.
+     * @param id    The id.
+     * @return      The matching entity.
+     */
+    T fetch(String id);
+
+    /**
+     * Fetches a {@link ListResult} containing all entities.
+     * @return  The {@link ListResult}.
+     */
+    ListResult<T> fetchAll();
+
+    /**
+     * Creates a new entity.
+     * @param entity    The entity.
+     * @return          The created entity.
+     */
+    T create(T entity);
+
+
+    /**
+     * Updates the specified entity.
+     * @param entity    The entity.
+     * @return          The previous value or null.
+     */
+    T update(T entity);
+
+
+    /**
+     * Delete the specified entity.
+     * @param entity    The entity.
+     * @return          True on successful deletion, false otherwise.
+     */
+    boolean delete(WithId<T> entity);
+
+
+    /**
+     * Delete the entity with the specified id.
+     * @param id        The id of the entity.
+     * @return          True on successful deletion, false otherwise.
+     */
+    boolean delete(String id);
+
+}

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/DataAccessObject.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/DataAccessObject.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.redhat.ipaas.api.v1.rest;
 
 import com.redhat.ipaas.api.v1.model.ListResult;

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/DataAccessObjectRegistry.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/DataAccessObjectRegistry.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.redhat.ipaas.api.v1.rest;
 
 import com.redhat.ipaas.api.v1.model.WithId;

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/DataAccessObjectRegistry.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/DataAccessObjectRegistry.java
@@ -1,0 +1,45 @@
+package com.redhat.ipaas.api.v1.rest;
+
+import com.redhat.ipaas.api.v1.model.WithId;
+import com.redhat.ipaas.api.v1.rest.exception.IPaasServerException;
+
+import java.util.Map;
+
+public interface DataAccessObjectRegistry {
+
+    Map<Class, DataAccessObject> getDataAccessObjectMapping();
+
+    /**
+     * Finds the {@link DataAccessObject} for the specified type.
+     * @param type  The class of the specified type.
+     * @param <T>   The specified type.
+     * @return      The {@link DataAccessObject} if found, or null no matching {@link DataAccessObject} was found.
+     */
+    default <T extends WithId> DataAccessObject<T> getDataAccessObject(Class<T> type) {
+        return getDataAccessObjectMapping().get(type);
+    }
+
+
+    /**
+     * Finds the {@link DataAccessObject} for the specified type.
+     * @param type  The class of the specified type.
+     * @param <T>   The specified type.
+     * @return      The {@link DataAccessObject} or throws {@link IPaasServerException}.
+     */
+    default <T extends WithId> DataAccessObject<T> getDataAccessObjectRequired(Class<T> type) {
+        DataAccessObject dao = getDataAccessObjectMapping().get(type);
+        if (dao != null) {
+            return (DataAccessObject<T>) getDataAccessObjectMapping().get(type);
+        }
+        throw new IllegalArgumentException("No data access object found for type: [" + type + "].");
+    }
+
+    /**
+     * Regiester a {@link DataAccessObject}.
+     * @param dataAccessObject  The {@link DataAccessObject} to register.
+     * @param <T>               The type of the {@link DataAccessObject}.
+     */
+    default <T extends WithId> void registerDataAccessObject(DataAccessObject<T> dataAccessObject) {
+        getDataAccessObjectMapping().put(dataAccessObject.getType(), dataAccessObject);
+    }
+}

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/IntegrationDAO.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/IntegrationDAO.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.redhat.ipaas.api.v1.rest;
 
 import com.redhat.ipaas.api.v1.model.Integration;

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/IntegrationDAO.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/IntegrationDAO.java
@@ -1,0 +1,147 @@
+package com.redhat.ipaas.api.v1.rest;
+
+import com.redhat.ipaas.api.v1.model.Integration;
+import com.redhat.ipaas.api.v1.model.ListResult;
+import com.redhat.ipaas.api.v1.model.WithId;
+import com.redhat.ipaas.api.v1.rest.exception.IPaasServerException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.ConfigMapList;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+@Named(Integration.KIND)
+@ApplicationScoped
+public class IntegrationDAO implements DataAccessObject<Integration> {
+
+    //The configuration key
+    public static final String CONFIGURATION_KEY = "configuration";
+
+    private KubernetesClient kubernetesClient;
+
+    public IntegrationDAO() {
+        this(new DefaultKubernetesClient());
+    }
+
+    @Inject
+    public IntegrationDAO(KubernetesClient kubernetesClient) {
+        this.kubernetesClient = kubernetesClient;
+    }
+
+    @Override
+    public Class<Integration> getType() {
+        return Integration.class;
+    }
+
+    @Override
+    public Integration fetch(String id) {
+        return toIntegration(kubernetesClient.configMaps().withName(id).get());
+    }
+
+    @Override
+    public ListResult<Integration> fetchAll() {
+        ConfigMapList list = kubernetesClient.configMaps().withLabel(Integration.LABEL_NAME).list();
+        List<ConfigMap> maps = list != null ? list.getItems() : Collections.emptyList();
+        List<Integration> integrations = maps.stream().map(c -> toIntegration(c)).collect(Collectors.toList());
+        return new ListResult.Builder<Integration>()
+            .items(integrations)
+            .totalCount(integrations.size())
+            .build();
+    }
+
+    @Override
+    public Integration create(Integration entity) {
+        return toIntegration(kubernetesClient.configMaps().create(toConfigMap(entity)));
+    }
+
+    @Override
+    public Integration update(Integration entity) {
+        String id = entity.getId().orElseThrow(() -> new IllegalArgumentException("Update integration requires an entity with an id."));
+        ConfigMap old = kubernetesClient.configMaps().withName(id).get();
+        if (old != null) {
+            ConfigMap updated = kubernetesClient.configMaps().withName(id).replace(toConfigMap(entity));
+            return toIntegration(old);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public boolean delete(WithId<Integration> entity) {
+        try {
+            return delete(entity.getId().orElseThrow(() -> new IllegalArgumentException("Delete integration requires an entity with an id.")));
+        } catch (Throwable t) {
+            throw IPaasServerException.launderThrowable(t);
+        }
+    }
+
+    @Override
+    public boolean delete(String id) {
+        return kubernetesClient.configMaps().withName(id).delete();
+    }
+
+    private static final boolean containsIntegration(ConfigMap configMap) {
+        return configMap != null && configMap.getMetadata().getLabels().containsKey(Integration.LABEL_NAME);
+    }
+
+    private static final Integration toIntegration(ConfigMap configMap) {
+        if (configMap == null) {
+            throw new IllegalArgumentException("ConfigMap cannot be null.");
+        }
+        if (configMap.getMetadata() == null) {
+            throw new IllegalArgumentException("ConfigMap metadata cannot be null.");
+        }
+        if (configMap.getMetadata().getName() == null || configMap.getMetadata().getName().isEmpty()) {
+            throw new IllegalArgumentException("ConfigMap name cannot be blank.");
+        }
+        if (!containsIntegration(configMap)) {
+            throw new IllegalArgumentException("ConfigMap with name: [" + configMap.getMetadata().getName() + "] does not contain an Integration.");
+        }
+
+        String id = configMap.getMetadata().getName();
+        String name = configMap.getMetadata().getLabels().get(Integration.LABEL_NAME);
+        String templateId = configMap.getMetadata().getLabels().get(Integration.LABEL_TEMPLATE_ID);
+        Map<String, String> data = configMap.getData();
+        String configuration = data != null ? data.get(CONFIGURATION_KEY) : null;
+
+        return new Integration.Builder().name(name)
+            .id(Optional.of(id))
+            .integrationTemplateId(Optional.ofNullable(templateId))
+            .configuration(configuration)
+            .build();
+    }
+
+    private static final ConfigMap toConfigMap(Integration integration) {
+        String id = integration.getId().orElseThrow(() -> new IllegalArgumentException("Integration requires an id."));
+        String name = integration.getName();
+        String templateId = integration.getIntegrationTemplateId().orElse(null);
+        String configuration = integration.getConfiguration().orElse(null);
+
+        ConfigMapBuilder builder = new ConfigMapBuilder()
+            .withNewMetadata()
+                .withName(id)
+                .addToLabels(Integration.LABEL_ID, id)
+                .addToLabels(Integration.LABEL_NAME, name)
+            .endMetadata();
+        if (templateId != null) {
+            builder.editMetadata().addToLabels(Integration.LABEL_TEMPLATE_ID, templateId);
+        }
+
+        if (configuration != null) {
+            builder.addToData(CONFIGURATION_KEY, configuration);
+        }
+        return builder.build();
+    }
+
+}

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/Integrations.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/Integrations.java
@@ -17,7 +17,6 @@ package com.redhat.ipaas.api.v1.rest;
 
 import com.redhat.ipaas.api.v1.model.Integration;
 import io.swagger.annotations.Api;
-
 import javax.ws.rs.Path;
 
 @Path("/integrations")

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/KubernetesClientProducer.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/KubernetesClientProducer.java
@@ -1,0 +1,16 @@
+package com.redhat.ipaas.api.v1.rest;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+@ApplicationScoped
+public class KubernetesClientProducer {
+
+    @Produces
+    public KubernetesClient create() {
+        return new DefaultKubernetesClient();
+    }
+}

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/KubernetesClientProducer.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/KubernetesClientProducer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.redhat.ipaas.api.v1.rest;
 
 import javax.enterprise.context.ApplicationScoped;

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/ModelData.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/ModelData.java
@@ -24,23 +24,26 @@ import com.fasterxml.jackson.databind.JsonNode;
  */
 public class ModelData {
 
-	private String model;
+	private String kind;
 	private Object data;
-	
-	
-	public ModelData(String model, Object data) {
+
+    public ModelData() {
+        super();
+    }
+
+	public ModelData(String kind, Object data) {
 		super();
-		this.model = model;
+		this.kind = kind;
 		this.data = data;
 	}
 
 
-	public String getModel() {
-		return model;
+	public String getKind() {
+		return kind;
 	}
 
-	public void setModel(String model) {
-		this.model = model;
+	public void setKind(String kind) {
+		this.kind = kind;
 	}
 
 	@JsonRawValue
@@ -51,9 +54,4 @@ public class ModelData {
 	public void setData(JsonNode data) {
 		this.data = data;
 	}
-
-	public ModelData() {
-		super();
-	}
-	
 }

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/ObjectMapperProducer.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/ObjectMapperProducer.java
@@ -18,14 +18,16 @@ package com.redhat.ipaas.api.v1.rest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
-class ObjectMapperHolder {
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
 
-    static final ObjectMapper OBJECT_MAPPER = createObjectMapper();
+@ApplicationScoped
+public class ObjectMapperProducer {
 
-    private static ObjectMapper createObjectMapper() {
+    @Produces
+    public ObjectMapper create() {
         ObjectMapper om = new ObjectMapper();
         om.registerModule(new Jdk8Module());
         return om;
     }
-
 }

--- a/api/src/main/resources/com/redhat/ipaas/api/v1/deployment.json
+++ b/api/src/main/resources/com/redhat/ipaas/api/v1/deployment.json
@@ -4,28 +4,28 @@
       "name": "Acme",
       "id": 1
     },
-    "model": "Organization"
+    "kind": "Organization"
   },
   {
     "data": {
       "name": "iPaaS Administrator",
       "id": 1
     },
-    "model": "Role"
+    "kind": "Role"
   },
   {
     "data": {
       "name": "Expert User",
        "id": 2
     },
-    "model": "Role"
+    "kind": "Role"
   },
   {
     "data": {
       "name": "Citizen User",
       "id": 3
     },
-    "model": "Role"
+    "kind": "Role"
   },
   {
     "data": {
@@ -35,7 +35,7 @@
       "lastName": "Freeman",
       "firstName": "Pearson"
     },
-    "model": "User"
+    "kind": "User"
   },
   {
     "data": {
@@ -45,7 +45,7 @@
       "lastName": "Yang",
       "firstName": "Sargent"
     },
-    "model": "User"
+    "kind": "User"
   },
   {
     "data": {
@@ -55,7 +55,7 @@
       "lastName": "Gamble",
       "firstName": "Sally"
     },
-    "model": "User"
+    "kind": "User"
   },
   {
     "data": {
@@ -65,7 +65,7 @@
       "lastName": "Donovan",
       "firstName": "Jodi"
     },
-    "model": "User"
+    "kind": "User"
   },
   {
     "data": {
@@ -75,7 +75,7 @@
       "lastName": "Wall",
       "firstName": "Ruthie"
     },
-    "model": "User"
+    "kind": "User"
   },
   {
     "data": {
@@ -85,7 +85,7 @@
       "lastName": "Singleton",
       "firstName": "Fitzgerald"
     },
-    "model": "User"
+    "kind": "User"
   },
   {
     "data": {
@@ -95,7 +95,7 @@
       "lastName": "Sargent",
       "firstName": "Lynn"
     },
-    "model": "User"
+    "kind": "User"
   },
   {
     "data": {
@@ -105,7 +105,7 @@
       "lastName": "Hogan",
       "firstName": "Jenkins"
     },
-    "model": "User"
+    "kind": "User"
   },
   {
     "data": {
@@ -115,7 +115,7 @@
       "lastName": "Gonzales",
       "firstName": "Melendez"
     },
-    "model": "User"
+    "kind": "User"
   },
   {
     "data": {
@@ -125,252 +125,252 @@
       "lastName": "Griffith",
       "firstName": "Lowery"
     },
-    "model": "User"
+    "kind": "User"
   },
   {
     "data": {
       "name": "fugiat",
       "id": 1
     },
-    "model": "ComponentGroup"
+    "kind": "ComponentGroup"
   },
   {
     "data": {
       "name": "cupidatat",
       "id": 2
     },
-    "model": "ComponentGroup"
+    "kind": "ComponentGroup"
   },
   {
     "data": {
       "name": "incididunt",
       "id": 3
     },
-    "model": "ComponentGroup"
+    "kind": "ComponentGroup"
   },
   {
     "data": {
       "name": "proident",
       "id": 4
     },
-    "model": "ComponentGroup"
+    "kind": "ComponentGroup"
   },
   {
     "data": {
       "name": "labore",
       "id": 5
     },
-    "model": "ComponentGroup"
+    "kind": "ComponentGroup"
   },
   {
     "data": {
       "name": "duis",
       "id": 6
     },
-    "model": "ComponentGroup"
+    "kind": "ComponentGroup"
   },
   {
     "data": {
       "name": "officia",
       "id": 7
     },
-    "model": "ComponentGroup"
+    "kind": "ComponentGroup"
   },
   {
     "data": {
       "name": "Lorem",
       "id": 8
     },
-    "model": "ComponentGroup"
+    "kind": "ComponentGroup"
   },
   {
     "data": {
       "name": "pariatur",
       "id": 9
     },
-    "model": "ComponentGroup"
+    "kind": "ComponentGroup"
   },
   {
     "data": {
       "name": "id",
       "id": 10
     },
-    "model": "ComponentGroup"
+    "kind": "ComponentGroup"
   },
   {
     "data": {
       "name": "est",
       "id": 11
     },
-    "model": "ComponentGroup"
+    "kind": "ComponentGroup"
   },
   {
     "data": {
       "name": "aliqua",
       "id": 12
     },
-    "model": "ComponentGroup"
+    "kind": "ComponentGroup"
   },
   {
     "data": {
       "name": "eu",
       "id": 13
     },
-    "model": "ComponentGroup"
+    "kind": "ComponentGroup"
   },
   {
     "data": {
       "name": "in",
       "id": 14
     },
-    "model": "ComponentGroup"
+    "kind": "ComponentGroup"
   },
   {
     "data": {
       "name": "et",
       "id": 15
     },
-    "model": "ComponentGroup"
+    "kind": "ComponentGroup"
   },
   {
     "data": {
       "name": "laborum",
       "id": 16
     },
-    "model": "ComponentGroup"
+    "kind": "ComponentGroup"
   },
   {
     "data": {
       "name": "eiusmod",
       "id": 17
     },
-    "model": "ComponentGroup"
+    "kind": "ComponentGroup"
   },
   {
     "data": {
       "name": "do",
       "id": 18
     },
-    "model": "ComponentGroup"
+    "kind": "ComponentGroup"
   },
   {
     "data": {
       "name": "minim",
       "id": 19
     },
-    "model": "ComponentGroup"
+    "kind": "ComponentGroup"
   },
   {
     "data": {
       "name": "dolor",
       "id": 20
     },
-    "model": "ComponentGroup"
+    "kind": "ComponentGroup"
   },
   {
     "data": {
       "name": "velit",
       "id": 21
     },
-    "model": "ComponentGroup"
+    "kind": "ComponentGroup"
   },
   {
     "data": {
       "name": "laboris",
       "id": 22
     },
-    "model": "ComponentGroup"
+    "kind": "ComponentGroup"
   },
   {
     "data": {
       "name": "aliquip",
       "id": 23
     },
-    "model": "ComponentGroup"
+    "kind": "ComponentGroup"
   },
   {
     "data": {
       "name": "aliqua",
       "id": 24
     },
-    "model": "ComponentGroup"
+    "kind": "ComponentGroup"
   },
   {
     "data": {
       "name": "non",
       "id": 25
     },
-    "model": "ComponentGroup"
+    "kind": "ComponentGroup"
   },
   {
     "data": {
       "name": "exercitation",
       "id": 1
     },
-    "model": "IntegrationPatternGroup"
+    "kind": "IntegrationPatternGroup"
   },
   {
     "data": {
       "name": "minim",
       "id": 2
     },
-    "model": "IntegrationPatternGroup"
+    "kind": "IntegrationPatternGroup"
   },
   {
     "data": {
       "name": "velit",
       "id": 3
     },
-    "model": "IntegrationPatternGroup"
+    "kind": "IntegrationPatternGroup"
   },
   {
     "data": {
       "name": "exercitation2",
       "id": 4
     },
-    "model": "IntegrationPatternGroup"
+    "kind": "IntegrationPatternGroup"
   },
   {
     "data": {
       "name": "cupidatat",
       "id": 5
     },
-    "model": "IntegrationPatternGroup"
+    "kind": "IntegrationPatternGroup"
   },
   {
     "data": {
       "name": "ea",
       "id": 6
     },
-    "model": "IntegrationPatternGroup"
+    "kind": "IntegrationPatternGroup"
   },
   {
     "data": {
       "name": "deserunt",
       "id": 7
     },
-    "model": "IntegrationPatternGroup"
+    "kind": "IntegrationPatternGroup"
   },
   {
     "data": {
       "name": "non",
       "id": 8
     },
-    "model": "IntegrationPatternGroup"
+    "kind": "IntegrationPatternGroup"
   },
   {
     "data": {
       "name": "et",
       "id": 9
     },
-    "model": "IntegrationPatternGroup"
+    "kind": "IntegrationPatternGroup"
   },
   {
     "data": {
       "name": "consequat",
       "id": 10
     },
-    "model": "IntegrationPatternGroup"
+    "kind": "IntegrationPatternGroup"
   },
   {
     "data": {
@@ -381,7 +381,7 @@
       "name": "non",
       "id": 1
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -392,7 +392,7 @@
       "name": "proident",
       "id": 2
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -403,7 +403,7 @@
       "name": "in",
       "id": 3
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -414,7 +414,7 @@
       "name": "excepteur",
       "id": 4
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -425,7 +425,7 @@
       "name": "est",
       "id": 5
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -436,7 +436,7 @@
       "name": "commodo",
       "id": 6
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -447,7 +447,7 @@
       "name": "ut",
       "id": 7
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -458,7 +458,7 @@
       "name": "magna",
       "id": 8
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -469,7 +469,7 @@
       "name": "ex",
       "id": 9
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -480,7 +480,7 @@
       "name": "Lorem",
       "id": 10
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -491,7 +491,7 @@
       "name": "irure",
       "id": 11
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -502,7 +502,7 @@
       "name": "ullamco",
       "id": 12
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -513,7 +513,7 @@
       "name": "velit",
       "id": 13
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -524,7 +524,7 @@
       "name": "dolore",
       "id": 14
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -535,7 +535,7 @@
       "name": "sint",
       "id": 15
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -546,7 +546,7 @@
       "name": "commodo",
       "id": 16
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -557,7 +557,7 @@
       "name": "amet",
       "id": 17
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -568,7 +568,7 @@
       "name": "ullamco",
       "id": 18
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -579,7 +579,7 @@
       "name": "ad",
       "id": 19
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -590,7 +590,7 @@
       "name": "dolore",
       "id": 20
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -601,7 +601,7 @@
       "name": "non",
       "id": 21
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -612,7 +612,7 @@
       "name": "velit",
       "id": 22
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -623,7 +623,7 @@
       "name": "Lorem",
       "id": 23
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -634,7 +634,7 @@
       "name": "consequat",
       "id": 24
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -645,7 +645,7 @@
       "name": "id",
       "id": 25
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -656,7 +656,7 @@
       "name": "aute",
       "id": 26
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -667,7 +667,7 @@
       "name": "veniam",
       "id": 27
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -678,7 +678,7 @@
       "name": "dolore",
       "id": 28
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -689,7 +689,7 @@
       "name": "ipsum",
       "id": 29
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -700,7 +700,7 @@
       "name": "ullamco",
       "id": 30
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -711,7 +711,7 @@
       "name": "ullamco",
       "id": 31
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -722,7 +722,7 @@
       "name": "esse",
       "id": 32
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -733,7 +733,7 @@
       "name": "amet",
       "id": 33
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -744,7 +744,7 @@
       "name": "aliqua",
       "id": 34
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -755,7 +755,7 @@
       "name": "enim",
       "id": 35
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -766,7 +766,7 @@
       "name": "consequat",
       "id": 36
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -777,7 +777,7 @@
       "name": "amet",
       "id": 37
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -788,7 +788,7 @@
       "name": "anim",
       "id": 38
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -799,7 +799,7 @@
       "name": "mollit",
       "id": 39
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -810,7 +810,7 @@
       "name": "non",
       "id": 40
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -821,7 +821,7 @@
       "name": "commodo",
       "id": 41
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -832,7 +832,7 @@
       "name": "ut",
       "id": 42
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -843,7 +843,7 @@
       "name": "veniam",
       "id": 43
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -854,7 +854,7 @@
       "name": "proident",
       "id": 44
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -865,7 +865,7 @@
       "name": "duis",
       "id": 45
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -876,7 +876,7 @@
       "name": "anim",
       "id": 46
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -887,7 +887,7 @@
       "name": "deserunt",
       "id": 47
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -898,7 +898,7 @@
       "name": "non",
       "id": 48
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -909,7 +909,7 @@
       "name": "excepteur",
       "id": 49
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -920,7 +920,7 @@
       "name": "consequat",
       "id": 50
     },
-    "model": "Component"
+    "kind": "Component"
   },
   {
     "data": {
@@ -934,7 +934,7 @@
       "name": "laboris",
       "id": 1
     },
-    "model": "Connection"
+    "kind": "Connection"
   },
   {
     "data": {
@@ -948,7 +948,7 @@
       "name": "dolor",
       "id": 2
     },
-    "model": "Connection"
+    "kind": "Connection"
   },
   {
     "data": {
@@ -962,7 +962,7 @@
       "name": "amet",
       "id": 3
     },
-    "model": "Connection"
+    "kind": "Connection"
   },
   {
     "data": {
@@ -976,7 +976,7 @@
       "name": "quis",
       "id": 4
     },
-    "model": "Connection"
+    "kind": "Connection"
   },
   {
     "data": {
@@ -990,7 +990,7 @@
       "name": "magna",
       "id": 5
     },
-    "model": "Connection"
+    "kind": "Connection"
   },
   {
     "data": {
@@ -1004,7 +1004,7 @@
       "name": "veniam",
       "id": 6
     },
-    "model": "Connection"
+    "kind": "Connection"
   },
   {
     "data": {
@@ -1018,7 +1018,7 @@
       "name": "aliquip",
       "id": 7
     },
-    "model": "Connection"
+    "kind": "Connection"
   },
   {
     "data": {
@@ -1032,7 +1032,7 @@
       "name": "non",
       "id": 8
     },
-    "model": "Connection"
+    "kind": "Connection"
   },
   {
     "data": {
@@ -1046,7 +1046,7 @@
       "name": "sint",
       "id": 9
     },
-    "model": "Connection"
+    "kind": "Connection"
   },
   {
     "data": {
@@ -1060,7 +1060,7 @@
       "name": "eu",
       "id": 10
     },
-    "model": "Connection"
+    "kind": "Connection"
   },
   {
     "data": {
@@ -1074,7 +1074,7 @@
       "name": "nulla",
       "id": 11
     },
-    "model": "Connection"
+    "kind": "Connection"
   },
   {
     "data": {
@@ -1088,7 +1088,7 @@
       "name": "elit",
       "id": 12
     },
-    "model": "Connection"
+    "kind": "Connection"
   },
   {
     "data": {
@@ -1102,7 +1102,7 @@
       "name": "nostrud",
       "id": 13
     },
-    "model": "Connection"
+    "kind": "Connection"
   },
   {
     "data": {
@@ -1116,7 +1116,7 @@
       "name": "velit",
       "id": 14
     },
-    "model": "Connection"
+    "kind": "Connection"
   },
   {
     "data": {
@@ -1130,7 +1130,7 @@
       "name": "id",
       "id": 15
     },
-    "model": "Connection"
+    "kind": "Connection"
   },
   {
     "data": {
@@ -1144,7 +1144,7 @@
       "name": "ea",
       "id": 16
     },
-    "model": "Connection"
+    "kind": "Connection"
   },
   {
     "data": {
@@ -1158,7 +1158,7 @@
       "name": "enim",
       "id": 17
     },
-    "model": "Connection"
+    "kind": "Connection"
   },
   {
     "data": {
@@ -1172,7 +1172,7 @@
       "name": "enim",
       "id": 18
     },
-    "model": "Connection"
+    "kind": "Connection"
   },
   {
     "data": {
@@ -1186,7 +1186,7 @@
       "name": "ullamco",
       "id": 19
     },
-    "model": "Connection"
+    "kind": "Connection"
   },
   {
     "data": {
@@ -1200,7 +1200,7 @@
       "name": "sunt",
       "id": 20
     },
-    "model": "Connection"
+    "kind": "Connection"
   },
   {
     "data": {
@@ -1214,7 +1214,7 @@
       "name": "adipisicing",
       "id": 21
     },
-    "model": "Connection"
+    "kind": "Connection"
   },
   {
     "data": {
@@ -1228,7 +1228,7 @@
       "name": "ullamco",
       "id": 22
     },
-    "model": "Connection"
+    "kind": "Connection"
   },
   {
     "data": {
@@ -1242,7 +1242,7 @@
       "name": "aliqua",
       "id": 23
     },
-    "model": "Connection"
+    "kind": "Connection"
   },
   {
     "data": {
@@ -1256,7 +1256,7 @@
       "name": "commodo",
       "id": 24
     },
-    "model": "Connection"
+    "kind": "Connection"
   },
   {
     "data": {
@@ -1270,7 +1270,7 @@
       "name": "consequat",
       "id": 25
     },
-    "model": "Connection"
+    "kind": "Connection"
   },
   {
     "data": {
@@ -1280,7 +1280,7 @@
       "name": "ea",
       "id": 1
     },
-    "model": "IntegrationTemplate"
+    "kind": "IntegrationTemplate"
   },
   {
     "data": {
@@ -1290,7 +1290,7 @@
       "name": "veniam",
       "id": 2
     },
-    "model": "IntegrationTemplate"
+    "kind": "IntegrationTemplate"
   },
   {
     "data": {
@@ -1300,7 +1300,7 @@
       "name": "dolor",
       "id": 3
     },
-    "model": "IntegrationTemplate"
+    "kind": "IntegrationTemplate"
   },
   {
     "data": {
@@ -1310,7 +1310,7 @@
       "name": "enim",
       "id": 4
     },
-    "model": "IntegrationTemplate"
+    "kind": "IntegrationTemplate"
   },
   {
     "data": {
@@ -1320,7 +1320,7 @@
       "name": "laborum",
       "id": 5
     },
-    "model": "IntegrationTemplate"
+    "kind": "IntegrationTemplate"
   },
   {
     "data": {
@@ -1330,7 +1330,7 @@
       "name": "non",
       "id": 6
     },
-    "model": "IntegrationTemplate"
+    "kind": "IntegrationTemplate"
   },
   {
     "data": {
@@ -1340,7 +1340,7 @@
       "name": "dolore",
       "id": 7
     },
-    "model": "IntegrationTemplate"
+    "kind": "IntegrationTemplate"
   },
   {
     "data": {
@@ -1350,7 +1350,7 @@
       "name": "do",
       "id": 8
     },
-    "model": "IntegrationTemplate"
+    "kind": "IntegrationTemplate"
   },
   {
     "data": {
@@ -1360,7 +1360,7 @@
       "name": "nostrud",
       "id": 9
     },
-    "model": "IntegrationTemplate"
+    "kind": "IntegrationTemplate"
   },
   {
     "data": {
@@ -1370,7 +1370,7 @@
       "name": "ea",
       "id": 10
     },
-    "model": "IntegrationTemplate"
+    "kind": "IntegrationTemplate"
   },
   {
     "data": {
@@ -1380,7 +1380,7 @@
       "name": "deserunt",
       "id": 1
     },
-    "model": "Integration"
+    "kind": "Integration"
   },
   {
     "data": {
@@ -1390,7 +1390,7 @@
       "name": "cillum",
       "id": 2
     },
-    "model": "Integration"
+    "kind": "Integration"
   },
   {
     "data": {
@@ -1400,7 +1400,7 @@
       "name": "nisi",
       "id": 3
     },
-    "model": "Integration"
+    "kind": "Integration"
   },
   {
     "data": {
@@ -1410,7 +1410,7 @@
       "name": "proident",
       "id": 4
     },
-    "model": "Integration"
+    "kind": "Integration"
   },
   {
     "data": {
@@ -1420,7 +1420,7 @@
       "name": "do",
       "id": 5
     },
-    "model": "Integration"
+    "kind": "Integration"
   },
   {
     "data": {
@@ -1430,7 +1430,7 @@
       "name": "dolor",
       "id": 6
     },
-    "model": "Integration"
+    "kind": "Integration"
   },
   {
     "data": {
@@ -1440,7 +1440,7 @@
       "name": "do2",
       "id": 7
     },
-    "model": "Integration"
+    "kind": "Integration"
   },
   {
     "data": {
@@ -1450,7 +1450,7 @@
       "name": "sit",
       "id": 8
     },
-    "model": "Integration"
+    "kind": "Integration"
   },
   {
     "data": {
@@ -1460,7 +1460,7 @@
       "name": "culpa",
       "id": 9
     },
-    "model": "Integration"
+    "kind": "Integration"
   },
   {
     "data": {
@@ -1470,6 +1470,6 @@
       "name": "minim",
       "id": 10
     },
-    "model": "Integration"
+    "kind": "Integration"
   }
 ]

--- a/api/src/test/java/com/redhat/ipaas/api/v1/rest/DataManagerTest.java
+++ b/api/src/test/java/com/redhat/ipaas/api/v1/rest/DataManagerTest.java
@@ -15,6 +15,7 @@
  */
 package com.redhat.ipaas.api.v1.rest;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.ipaas.api.v1.model.Component;
 import com.redhat.ipaas.api.v1.model.Integration;
 import com.redhat.ipaas.api.v1.model.ListResult;
@@ -32,11 +33,12 @@ public class DataManagerTest {
 
     @Rule
     public InfinispanCache infinispan = new InfinispanCache();
+    private ObjectMapper objectMapper = new ObjectMapperProducer().create();
     private DataManager dataManager = null;
 
     @Before
     public void setupCache() {
-        dataManager = new DataManager("com/redhat/ipaas/api/v1/deployment.json", infinispan.getCache());
+        dataManager = new DataManager(infinispan.getCache(), objectMapper, "com/redhat/ipaas/api/v1/deployment.json");
         dataManager.init();
     }
 

--- a/api/src/test/java/com/redhat/ipaas/api/v1/rest/DataManagerTest.java
+++ b/api/src/test/java/com/redhat/ipaas/api/v1/rest/DataManagerTest.java
@@ -38,7 +38,7 @@ public class DataManagerTest {
 
     @Before
     public void setupCache() {
-        dataManager = new DataManager(infinispan.getCache(), objectMapper, "com/redhat/ipaas/api/v1/deployment.json");
+        dataManager = new DataManager(infinispan.getCaches(), objectMapper, "com/redhat/ipaas/api/v1/deployment.json");
         dataManager.init();
     }
 

--- a/api/src/test/java/com/redhat/ipaas/api/v1/rest/InfinispanCache.java
+++ b/api/src/test/java/com/redhat/ipaas/api/v1/rest/InfinispanCache.java
@@ -15,31 +15,25 @@
  */
 package com.redhat.ipaas.api.v1.rest;
 
-import com.redhat.ipaas.api.v1.model.WithId;
-import org.infinispan.Cache;
+import org.infinispan.manager.CacheContainer;
 import org.infinispan.manager.DefaultCacheManager;
-import org.infinispan.manager.EmbeddedCacheManager;
 import org.junit.rules.ExternalResource;
-
-import java.util.Map;
 
 public class InfinispanCache extends ExternalResource {
 
-    private EmbeddedCacheManager cacheManager;
-    private Cache<String, Map<String, WithId>> cache;
+    private CacheContainer caches;
 
     @Override
     protected void before() throws Throwable {
-        cacheManager = new DefaultCacheManager();
-        cache = cacheManager.getCache();
+        caches = new DefaultCacheManager();
     }
 
     @Override
     protected void after() {
-        cacheManager.stop();
+        caches.stop();
     }
 
-    public Cache<String, Map<String, WithId>> getCache() {
-        return cache;
+    public CacheContainer getCaches() {
+        return caches;
     }
 }

--- a/api/src/test/java/com/redhat/ipaas/api/v1/rest/ReadApiClientDataTest.java
+++ b/api/src/test/java/com/redhat/ipaas/api/v1/rest/ReadApiClientDataTest.java
@@ -59,7 +59,7 @@ public class ReadApiClientDataTest {
 		assertTrue("We should find some ModelData", 0 < modelDataList.size());
 		List<ComponentGroup> componentGroupList = new ArrayList<ComponentGroup>();
 		for (ModelData md : modelDataList) {
-			if (md.getModel().equalsIgnoreCase("componentgroup")) {
+			if (md.getKind().equalsIgnoreCase("componentgroup")) {
 				ComponentGroup cg = mapper.readValue(md.getData(), ComponentGroup.class);
 				componentGroupList.add(cg);
 			}

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,8 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
+    <kubernetes.client.version>1.4.33</kubernetes.client.version>
+    <mockwebserver.version>0.0.4</mockwebserver.version>
     <wildfly.swarm.version>2016.11.0</wildfly.swarm.version>
     <version.infinispan>9.0.0.Alpha4</version.infinispan>
     <immutables.version>2.4.0</immutables.version>
@@ -147,6 +149,14 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- Import Boms -->
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>kubernetes-client-bom-with-deps</artifactId>
+        <version>${kubernetes.client.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>bom-all</artifactId>
@@ -169,6 +179,7 @@
         <type>pom</type>
       </dependency>
 
+      <!-- Internal Dependencies -->
       <dependency>
         <groupId>com.redhat.ipaas</groupId>
         <artifactId>api</artifactId>
@@ -216,12 +227,29 @@
         <version>${slf4j.api.version}</version>
       </dependency>
 
+      <!-- Testing Dependencies -->
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
         <scope>test</scope>
       </dependency>
+
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>kubernetes-client</artifactId>
+        <version>${kubernetes.client.version}</version>
+        <type>test-jar</type>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>mockwebserver</artifactId>
+        <version>${mockwebserver.version}</version>
+        <scope>test</scope>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
This is work in progress, which means that you can review, provide feedback, but its not to be merged yet.

The end goal is to create a back-end for Integrations. 

At this point an integration can be a configmap or secret, with a special kind of label that indicates its an integration. The back end can be a simple cdi bean that talks to the openshift rest api in order to read/write the config maps. 

To do so we need to make some changes, like being able to hook back-end service to the data manager, and also integrate with the cache.

So far the pull request addresses two things:

- Align naming around kind, which sometimes is called model.
- Convert a plain singleton into CDI produces application scoped bean.
- Change the way we are handling caches, so that we can have a cache per kind, rather than a map per kind.
- Introduce the DataAccessObject interface
- Hook DataAccessObject with DataManager
- Implement Integrations DataAccessObject.
