### PR TITLE
Introduce Integration Patterns DAO

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -69,6 +69,11 @@
       <artifactId>kubernetes-client</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.fabric8.funktion</groupId>
+      <artifactId>funktion-model</artifactId>
+    </dependency>
+
     <!-- Testing Dependencies -->
     <dependency>
       <groupId>io.fabric8</groupId>

--- a/api/src/main/java/com/redhat/ipaas/api/v1/model/IntegrationPattern.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/model/IntegrationPattern.java
@@ -21,9 +21,20 @@ import org.immutables.value.Value;
 import java.io.Serializable;
 import java.util.Optional;
 
+import io.fabric8.funktion.model.StepKinds;
+
 @Value.Immutable
 @JsonDeserialize(builder = IntegrationPattern.Builder.class)
 public interface IntegrationPattern extends WithId<IntegrationPattern>, WithName, Serializable {
+
+    IntegrationPattern CHOICE = new IntegrationPattern.Builder().id(StepKinds.OTHERWISE).name("Choice").build();
+    IntegrationPattern OTHERWISE = new IntegrationPattern.Builder().id(StepKinds.OTHERWISE).name("Otherwise").build();
+    IntegrationPattern MESSAGE_FILTER = new IntegrationPattern.Builder().id(StepKinds.FILTER).name("Message Filter").build();
+    IntegrationPattern SPLITTER = new IntegrationPattern.Builder().id(StepKinds.SPLIT).name("Splitter").build();
+    IntegrationPattern THROTTLER = new IntegrationPattern.Builder().id(StepKinds.THROTTLE).name("Throttler").build();
+
+    IntegrationPattern SET_BODY = new IntegrationPattern.Builder().id(StepKinds.SET_BODY).name("Set Body").build();
+    IntegrationPattern SET_HEDER = new IntegrationPattern.Builder().id(StepKinds.SET_HEADERS).name("Set Headers").build();
 
     String KIND = "integrationpattern";
 

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/CacheManagerProducer.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/CacheManagerProducer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.redhat.ipaas.api.v1.rest;
 
 import org.infinispan.configuration.cache.Configuration;

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/CacheManagerProducer.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/CacheManagerProducer.java
@@ -1,0 +1,33 @@
+package com.redhat.ipaas.api.v1.rest;
+
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfiguration;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.eviction.EvictionStrategy;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+@ApplicationScoped
+public class CacheManagerProducer {
+
+    @Produces
+    public EmbeddedCacheManager create() {
+        GlobalConfiguration g = new GlobalConfigurationBuilder()
+            .clusteredDefault()
+            .transport()
+            .clusterName("InfinispanCluster")
+            .build();
+
+        Configuration cfg = new ConfigurationBuilder()
+            .eviction()
+            .strategy(EvictionStrategy.LRU)
+            .maxEntries(150)
+            .build();
+
+        return new DefaultCacheManager(g, cfg);
+    }
+}

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/DataAccessObjectProvider.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/DataAccessObjectProvider.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.redhat.ipaas.api.v1.rest;
 
 import java.util.List;

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/DataAccessObjectProvider.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/DataAccessObjectProvider.java
@@ -1,0 +1,8 @@
+package com.redhat.ipaas.api.v1.rest;
+
+import java.util.List;
+
+public interface DataAccessObjectProvider {
+
+    List<DataAccessObject> getDataAccessObjects();
+}

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/DataManager.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/DataManager.java
@@ -80,18 +80,18 @@ public class DataManager implements DataAccessObjectRegistry {
     }
 
     // Constructor to help with testing.
-    public DataManager(CacheContainer caches, ObjectMapper mapper, List<DataAccessObject> dataAccessObjects, String dataFileName) {
+    public DataManager(CacheContainer caches, ObjectMapper mapper, DataAccessObjectProvider dataAccessObjects, String dataFileName) {
         this(caches, mapper, dataAccessObjects);
         this.dataFileName = dataFileName;
     }
 
     // Inject mandatory via constructor injection.
     @Inject
-    public DataManager(CacheContainer caches, ObjectMapper mapper, List<DataAccessObject> dataAccessObjects) {
+    public DataManager(CacheContainer caches, ObjectMapper mapper,  DataAccessObjectProvider dataAccessObjects) {
         this.mapper = mapper;
         this.caches = caches;
         if (dataAccessObjects != null) {
-            this.dataAccessObjects.addAll(dataAccessObjects);
+            this.dataAccessObjects.addAll(dataAccessObjects.getDataAccessObjects());
         }
     }
 

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/DataManager.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/DataManager.java
@@ -199,7 +199,13 @@ public class DataManager implements DataAccessObjectRegistry {
 
     @SuppressWarnings("unchecked")
     public <T extends WithId> ListResult<T> fetchAll(String kind, Function<ListResult<T>, ListResult<T>>... operators) {
-        Map<String, WithId> cache = caches.getCache(kind);
+        Cache<String, WithId> cache = caches.getCache(kind);
+
+        //TODO: This is currently broken and needs to be properly addressed.
+        //... until then just use the cache for pre-loaded data.
+        if (cache.isEmpty()) {
+            return (ListResult<T>) doWithDataAccessObject(kind, d -> d.fetchAll());
+        }
 
         ListResult<T> result = new ListResult.Builder<T>()
             .items((Collection<T>) cache.values())

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/DefaultDataAccessObjectProvider.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/DefaultDataAccessObjectProvider.java
@@ -1,0 +1,21 @@
+package com.redhat.ipaas.api.v1.rest;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class DefaultDataAccessObjectProvider implements DataAccessObjectProvider {
+
+    @Inject
+    private IntegrationDAO integrationDAO;
+
+    @Inject
+    private IntegrationPatternDAO integrationPatternDAO;
+
+    public List<DataAccessObject> getDataAccessObjects() {
+        return Arrays.asList(integrationDAO, integrationPatternDAO);
+    }
+}

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/DefaultDataAccessObjectProvider.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/DefaultDataAccessObjectProvider.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.redhat.ipaas.api.v1.rest;
 
 import java.util.Arrays;

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/IntegrationPatternDAO.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/IntegrationPatternDAO.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.ipaas.api.v1.rest;
+
+import com.redhat.ipaas.api.v1.model.IntegrationPattern;
+import com.redhat.ipaas.api.v1.model.ListResult;
+import com.redhat.ipaas.api.v1.model.WithId;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
+@Named(IntegrationPattern.KIND)
+@ApplicationScoped
+public class IntegrationPatternDAO implements DataAccessObject<IntegrationPattern> {
+
+    private static final Map<String, IntegrationPattern> PATTERNS = new HashMap<>();
+
+    private static void register(IntegrationPattern pattern) {
+        PATTERNS.put(pattern.getId().orElseThrow(()->new IllegalStateException("Integration Pattern requires an ID.")), pattern);
+    }
+
+    public IntegrationPatternDAO() {
+        register(IntegrationPattern.CHOICE);
+        register(IntegrationPattern.OTHERWISE);
+        register(IntegrationPattern.SPLITTER);
+        register(IntegrationPattern.THROTTLER);
+        register(IntegrationPattern.MESSAGE_FILTER);
+        register(IntegrationPattern.SET_BODY);
+        register(IntegrationPattern.SET_HEDER);
+    }
+
+    @Override
+    public Class<IntegrationPattern> getType() {
+        return IntegrationPattern.class;
+    }
+
+    @Override
+    public IntegrationPattern fetch(String id) {
+        return PATTERNS.get(id);
+    }
+
+    @Override
+    public ListResult<IntegrationPattern> fetchAll() {
+        return new ListResult.Builder<IntegrationPattern>()
+            .items(PATTERNS.values())
+            .totalCount(PATTERNS.size())
+            .build();
+    }
+
+    @Override
+    public IntegrationPattern create(IntegrationPattern entity) {
+        throw new UnsupportedOperationException("You can't create an Integration Pattern.");
+    }
+
+    @Override
+    public IntegrationPattern update(IntegrationPattern entity) {
+        throw new UnsupportedOperationException("You can't modify an Integration Pattern.");
+    }
+
+    @Override
+    public boolean delete(WithId<IntegrationPattern> entity) {
+        throw new UnsupportedOperationException("You can't delete an Integration Pattern.");
+    }
+
+    @Override
+    public boolean delete(String id) {
+        throw new UnsupportedOperationException("You can't delete an Integration Pattern.");
+    }
+}

--- a/api/src/test/java/com/redhat/ipaas/api/v1/rest/DataManagerTest.java
+++ b/api/src/test/java/com/redhat/ipaas/api/v1/rest/DataManagerTest.java
@@ -24,6 +24,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import javax.persistence.EntityExistsException;
@@ -43,16 +44,20 @@ public class DataManagerTest {
     private ObjectMapper objectMapper = new ObjectMapperProducer().create();
     private DataManager dataManager = null;
 
-    private final List<DataAccessObject> dataAccessObjects = new ArrayList<>();
 
     private static final KubernetesMockServer MOCK = new KubernetesMockServer();
 
 
     @Before
     public void setup() {
-        dataAccessObjects.add(new IntegrationDAO(MOCK.createClient()));
+        DataAccessObjectProvider dataAccessObjectProvider = new DataAccessObjectProvider() {
+            @Override
+            public List<DataAccessObject> getDataAccessObjects() {
+                return Arrays.asList(new IntegrationDAO(MOCK.createClient()));
+            }
+        };
         //Create Data Manager
-        dataManager = new DataManager(infinispan.getCaches(), objectMapper, dataAccessObjects, "com/redhat/ipaas/api/v1/deployment.json");
+        dataManager = new DataManager(infinispan.getCaches(), objectMapper, dataAccessObjectProvider, "com/redhat/ipaas/api/v1/deployment.json");
         dataManager.init();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
+    <funktion.version>1.1.44</funktion.version>
     <kubernetes.client.version>1.4.33</kubernetes.client.version>
     <mockwebserver.version>0.0.4</mockwebserver.version>
     <wildfly.swarm.version>2016.11.0</wildfly.swarm.version>
@@ -194,6 +195,13 @@
         <groupId>com.redhat.ipaas</groupId>
         <artifactId>swagger-ui</artifactId>
         <version>${project.version}</version>
+      </dependency>
+
+      <!-- Funktion -->
+      <dependency>
+        <groupId>io.fabric8.funktion</groupId>
+        <artifactId>funktion-model</artifactId>
+        <version>${funktion.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
This pull reuqest adds a readonly DAO for integration patterns. 

Patterns are loaded from the funktion model. (stepkinds -> integration patterns).

Along with this the pull request also fixes 3 side issues:
- broken injection of cachecontainer
- broken injection of list of daos
- fetchAll not working correctly.
