### PR TITLE
Various Docker updates

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -39,7 +39,6 @@ deployment:
     branch: master
     commands:
     - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD -e $DOCKER_EMAIL
-    - docker tag ipaas/runtime:latest rhipaas/ipaas-rest:latest
     - docker push rhipaas/ipaas-rest:latest | cat -
     - curl -sSL https://github.com/openshift/origin/releases/download/v1.4.1/openshift-origin-client-tools-v1.4.1-3f9807a-linux-64bit.tar.gz | sudo tar xz -C /usr/bin --strip-components 1
     - oc login --server=${OPENSHIFT_APISERVER} --token=${OPENSHIFT_TOKEN}

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <maven.jacoco.plugin.version>0.7.8</maven.jacoco.plugin.version>
     <maven.license.plugin.version>3.0</maven.license.plugin.version>
 
-    <fabric8.maven.plugin.version>3.2.8</fabric8.maven.plugin.version>
+    <fabric8.maven.plugin.version>3.2.15</fabric8.maven.plugin.version>
     <javaee.api.version>7.0</javaee.api.version>
     <hibernate.validator.version>5.3.4.Final</hibernate.validator.version>
   </properties>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -65,6 +65,15 @@
         <groupId>io.fabric8</groupId>
         <artifactId>fabric8-maven-plugin</artifactId>
         <version>${fabric8.maven.plugin.version}</version>
+        <configuration>
+          <generator>
+            <config>
+              <wildfly-swarm>
+                <name>rhipaas/ipaas-rest:%l</name>
+              </wildfly-swarm>
+            </config>
+          </generator>
+        </configuration>
       </plugin>
 
       <plugin>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -36,6 +36,8 @@
     <apidocs.output.dir>${project.build.outputDirectory}</apidocs.output.dir>
 
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
+
+    <java-image.version>1.2</java-image.version>
   </properties>
 
   <build>
@@ -70,6 +72,7 @@
             <config>
               <wildfly-swarm>
                 <name>rhipaas/ipaas-rest:%l</name>
+                <from>fabric8/java-jboss-openjdk8-jdk:${java-image.version}</from>
               </wildfly-swarm>
             </config>
           </generator>

--- a/runtime/src/main/fabric8/deployment.yml
+++ b/runtime/src/main/fabric8/deployment.yml
@@ -19,7 +19,10 @@ spec:
   template:
     spec:
       containers:
-      - resources:
+      - env:
+        - name: JAVA_OPTIONS
+          value: "-Djava.net.preferIPv4Stack=true"
+        resources:
           limits:
             cpu: 1000m
             memory: 612Mi


### PR DESCRIPTION
* Prefer ipv6 stack to prevent problems on ipv6 enabled servers
* Use JBoss base image to build on
* Use correct name for image
* Use latest fabric8 maven plugin
* Push image to docker hub from circleci