### PR TITLE
Saving to cache only

### DIFF
--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/DataManager.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/DataManager.java
@@ -230,8 +230,7 @@ public class DataManager implements DataAccessObjectRegistry {
             }
         }
 
-        T finalEntity = entity;
-        cache.put(idVal, (T) doWithDataAccessObject(kind, d -> d.create(finalEntity)));
+        cache.put(idVal, entity);
         return entity;
     }
 


### PR DESCRIPTION
@gashcrumb @jimmidyson if saving the integration keeps having issues like https://gist.github.com/gashcrumb/263c25b34e4d0bbf75139011622a3b9c
then we can disable saving to a configmap with this PR.