### PR TITLE
Add an ipaas-ui client id to the keycloak realm

### DIFF
--- a/runtime/src/test/resources/ipaas-keycloak-realm.json
+++ b/runtime/src/test/resources/ipaas-keycloak-realm.json
@@ -58,6 +58,37 @@
       "enabled": true,
       "publicClient": false,
       "bearerOnly": true
+    },
+    {
+      "clientId": "ipaas-ui",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [ "http://localhost:4200/*" ],
+      "webOrigins": [ "+" ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.force.post.binding": "false",
+        "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "saml.authnstatement": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false"
+      },
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": -1
     }
   ],
   "clientScopeMappings": {


### PR DESCRIPTION
Add an ipaas-ui client id to the keycloak realm so that the ./start-with-keycloak.sh script in this project can be used with the default ‘yarn start’ command in the ipaas-client and have the oauth just work. (cherry picked from commit a757b75234b3c50ff28e911dd997e652261c05e9)