### PR TITLE
Consistent naming of integration ConfigMap labels

### DIFF
--- a/rest/src/main/java/com/redhat/ipaas/rest/v1/model/integration/Integration.java
+++ b/rest/src/main/java/com/redhat/ipaas/rest/v1/model/integration/Integration.java
@@ -31,20 +31,23 @@ public interface Integration extends WithId<Integration>, WithName, Serializable
 
     String KIND = "integration";
 
-    /**
-     *Required Labels
-     */
-    String LABEL_NAME = "ipaas.redhat.com/integration-name";
+    // Labels used in config-map used for holding integrations
+    enum Label {
+        NAME("ipaas.redhat.com/integration/name",true),
+        ID("ipaas.redhat.com/integration/id",false),
+        TEMPLATE("ipaas.redhat.com/integration/template",false);
 
-    /**
-     * Optional Labels
-     */
+        private final boolean required;
+        private final String label;
 
-    //The integration id
-    String LABEL_ID = "ipaas.redhat.com/integration-id";
+        Label(String label, boolean required) {
+            this.label = label;
+            this.required = required;
+        }
 
-    //The integration template id
-    String LABEL_TEMPLATE_ID = "ipaas.redhat.com/template-id";
+        public String value() { return label; }
+        public boolean isRequired() { return required; }
+    }
 
     @Override
     default String getKind() {

--- a/rest/src/test/java/com/redhat/ipaas/rest/v1/dao/DataManagerTest.java
+++ b/rest/src/test/java/com/redhat/ipaas/rest/v1/dao/DataManagerTest.java
@@ -102,8 +102,8 @@ public class DataManagerTest {
         ConfigMap configMap1 = new ConfigMapBuilder()
             .withNewMetadata()
             .withName("integration1")
-            .addToLabels(Integration.LABEL_ID, "id1")
-            .addToLabels(Integration.LABEL_NAME, "integration one")
+            .addToLabels(Integration.Label.ID.value(), "id1")
+            .addToLabels(Integration.Label.NAME.value(), "integration one")
             .endMetadata()
             .addToData(IntegrationDAO.CONFIGURATION_KEY, "someconfig")
             .build();
@@ -125,8 +125,8 @@ public class DataManagerTest {
         ConfigMap configMap2 = new ConfigMapBuilder()
             .withNewMetadata()
             .withName("integration2")
-            .addToLabels(Integration.LABEL_ID, "id2")
-            .addToLabels(Integration.LABEL_NAME, "integration two")
+            .addToLabels(Integration.Label.ID.value(), "id2")
+            .addToLabels(Integration.Label.NAME.value(), "integration two")
             .endMetadata()
             .addToData(IntegrationDAO.CONFIGURATION_KEY, "someconfig")
             .build();


### PR DESCRIPTION
and inroduced enums to make it slightly more typesafe (and baked in the
comment 'mandatory' into the enum, not sure whether its needed).

Not even sure whether this is needed as the backend probably moves to a DB anyway.

Feel free to reject this PR :)