### PR TITLE
Honor the application.properties CORS config for OPTIONS requests

### DIFF
--- a/rest/src/main/java/com/redhat/ipaas/rest/v1/controller/SwaggerConfiguration.java
+++ b/rest/src/main/java/com/redhat/ipaas/rest/v1/controller/SwaggerConfiguration.java
@@ -21,6 +21,7 @@ import io.swagger.jaxrs.listing.SwaggerSerializers;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import javax.ws.rs.OPTIONS;
 import javax.ws.rs.Path;
 
 @Configuration
@@ -29,6 +30,9 @@ public class SwaggerConfiguration {
     @AllowedOrigins("*")
     @Path("/swagger.{type:json|yaml}")
     public static class IPaasApiListingResource extends ApiListingResource {
+
+        @OPTIONS
+        public void options() {}
     }
 
     @Bean


### PR DESCRIPTION
Ok implement better default option handling for the CORS case.  Previous hack would report a 200 status even for nonexistent paths.  This fix is much better and honors the applicaiton.properties cors config for OPTIONS requests.