### PR TITLE
Host the WebSocket endpoint under /api/v1/events.ws/*

### DIFF
--- a/runtime/src/main/java/com/redhat/ipaas/runtime/Application.java
+++ b/runtime/src/main/java/com/redhat/ipaas/runtime/Application.java
@@ -19,10 +19,13 @@ import com.redhat.ipaas.rest.v1.V1Application;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.embedded.undertow.UndertowDeploymentInfoCustomizer;
 import org.springframework.boot.context.embedded.undertow.UndertowEmbeddedServletContainerFactory;
 import org.springframework.boot.web.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+
+import java.util.List;
 
 @SpringBootApplication
 @ComponentScan(basePackageClasses = {V1Application.class, Application.class})
@@ -34,9 +37,11 @@ public class Application extends SpringBootServletInitializer {
 
     @Bean
     @Autowired
-    public UndertowEmbeddedServletContainerFactory embeddedServletContainerFactory(SimpleEventBus bus, EventBusToServerSentEvents sseUndertowCustomizer) {
+    public UndertowEmbeddedServletContainerFactory embeddedServletContainerFactory(SimpleEventBus bus, List<UndertowDeploymentInfoCustomizer> customizers) {
         UndertowEmbeddedServletContainerFactory factory = new UndertowEmbeddedServletContainerFactory();
-        factory.addDeploymentInfoCustomizers(sseUndertowCustomizer);
+        for (UndertowDeploymentInfoCustomizer customizer : customizers) {
+            factory.addDeploymentInfoCustomizers(customizer);
+        }
         return factory;
     }
 

--- a/runtime/src/main/java/com/redhat/ipaas/runtime/KeycloakConfiguration.java
+++ b/runtime/src/main/java/com/redhat/ipaas/runtime/KeycloakConfiguration.java
@@ -75,7 +75,6 @@ public class KeycloakConfiguration extends KeycloakWebSecurityConfigurerAdapter 
             .antMatchers(HttpMethod.OPTIONS).permitAll()
             .antMatchers("/api/v1/swagger.*").permitAll()
             .antMatchers("/api/v1/**").authenticated()
-            .antMatchers("/wsevents").authenticated()
             .anyRequest().permitAll();
 
         http.csrf().disable();


### PR DESCRIPTION
In short none of the SB web stuff can co-exist under /api/v1 as that’s 
being handled by resteasy.  Changed the impl to use a Undertow handler
similar to the SSE impl.  The two are more closely aligned now.