### PR TITLE
Ensure JsonDB orders by path

### DIFF
--- a/jsondb/src/main/java/com/redhat/ipaas/jsondb/impl/SqlJsonDB.java
+++ b/jsondb/src/main/java/com/redhat/ipaas/jsondb/impl/SqlJsonDB.java
@@ -116,7 +116,7 @@ public class SqlJsonDB implements JsonDB {
         Consumer<OutputStream> result = null;
         final Handle h = dbi.open();
         try {
-            ResultIterator<JsonRecord> iterator = h.createQuery("select path,value,kind from jsondb where path LIKE :like")
+            ResultIterator<JsonRecord> iterator = h.createQuery("select path,value,kind from jsondb where path LIKE :like order by path")
                 .bind("like", like)
                 .map(JsonRecordMapper.INSTANCE)
                 .iterator();


### PR DESCRIPTION
Otherwise DB records were not consistently allocated to correct object...