### PR TITLE
WIP adding status to Integration

### DIFF
--- a/model/src/main/java/com/redhat/ipaas/model/integration/Integration.java
+++ b/model/src/main/java/com/redhat/ipaas/model/integration/Integration.java
@@ -31,6 +31,10 @@ import org.immutables.value.Value;
 public interface Integration extends WithId<Integration>, WithName, Serializable {
 
     String KIND = "integration";
+    
+    public enum Type {Activated, Deactivated};
+    
+    public enum Phase {Pending, Running, Succeeded, Failed, Unknown};
 
     /**
      *Required Labels
@@ -71,6 +75,10 @@ public interface Integration extends WithId<Integration>, WithName, Serializable
     Optional<String> getDescription();
 
     Optional<String> getGitRepo();
+
+    Optional<Enum<Type>> getStatusType();
+
+    Optional<Enum<Phase>> getStatusPhase();
 
     @Override
     default Integration withId(String id) {


### PR DESCRIPTION
Trying to keep it as simple as possible by simply adding two fields to  `Integration`: statusType and statusPhase.

In PUT request on /integrations/<id> the statusType can be set to 'Activated' or 'Deactivated'. This would then trigger Activation or Deactivation of the integration. The runtime (kubernetes watcher?) will update the statusPhase.

Comments welcome. 
