### PR TITLE
Optimization for GitHub service

### DIFF
--- a/github/src/main/java/com/redhat/ipaas/github/SpringGitServiceFactory.java
+++ b/github/src/main/java/com/redhat/ipaas/github/SpringGitServiceFactory.java
@@ -18,6 +18,7 @@ package com.redhat.ipaas.github;
 import com.redhat.ipaas.github.backend.ExtendedContentsService;
 import com.redhat.ipaas.github.backend.KeycloakTokenAwareGitHubClient;
 import org.eclipse.egit.github.core.service.RepositoryService;
+import org.eclipse.egit.github.core.service.UserService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -43,5 +44,11 @@ public class SpringGitServiceFactory {
     @Scope("request")
     public ExtendedContentsService contentsService() {
         return new ExtendedContentsService(new KeycloakTokenAwareGitHubClient(gitHubHost));
+    }
+
+    @Bean
+    @Scope("request")
+    public UserService userService() {
+        return new UserService(new KeycloakTokenAwareGitHubClient(gitHubHost));
     }
 }

--- a/github/src/test/java/com/redhat/ipaas/github/GitHubServiceImplTest.java
+++ b/github/src/test/java/com/redhat/ipaas/github/GitHubServiceImplTest.java
@@ -24,7 +24,7 @@ public class GitHubServiceImplTest {
 
     @Test
     public void sanitizeRepoName() throws Exception {
-        GitHubService service = new GitHubServiceImpl(null, null);
+        GitHubService service = new GitHubServiceImpl(null, null, null);
 
         String data[] = {
             "bla", "bla",


### PR DESCRIPTION
Instead of fetching all repositories and iterate over it (1 API call), fetch now the current user and fetch a repository directly (2 API calls).

It seems that this variant is not much faster, but more predictable as it not depends on the number of repoistories given.