### PR TITLE
Change to using the most recent Fuse Camel 2.19 version.  

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
 
     <assertj-core.version>3.6.2</assertj-core.version>
-    <camel.version>2.19.0-SNAPSHOT</camel.version>
+    <camel.version>2.19.0.fuse-000016</camel.version>
     <jdbi.version>2.78</jdbi.version>
     <funktion.version>1.1.55</funktion.version>
     <hibernate.validator.version>5.3.4.Final</hibernate.validator.version>


### PR DESCRIPTION
Apache site is timing out during use of 2.19 SNAPSHOT, change to using most recent Fuse 7-built Camel 2.19 version.