### PR TITLE
Enabeling reading Enums as Strings from JSON

### DIFF
--- a/core/src/main/java/com/redhat/ipaas/core/Json.java
+++ b/core/src/main/java/com/redhat/ipaas/core/Json.java
@@ -16,6 +16,7 @@
 package com.redhat.ipaas.core;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
@@ -26,7 +27,8 @@ public class Json {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
         .registerModule(new Jdk8Module())
-        .setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
+        .setSerializationInclusion(JsonInclude.Include.NON_ABSENT)
+        .configure(DeserializationFeature.READ_ENUMS_USING_TO_STRING,true);
 
     private Json() {
     }

--- a/dao/src/main/resources/com/redhat/ipaas/dao/deployment.json
+++ b/dao/src/main/resources/com/redhat/ipaas/dao/deployment.json
@@ -370,6 +370,10 @@
       "name": "Twitter to Salesforce Example",
       "description": "This is an example of a Twitter to Salesforce integration",
       "configuration": "",
+      "statusType": "Activated",
+      "tags": [
+        { "name": "example" }
+       ],
       "steps": [
         {
           "id": "1",
@@ -451,6 +455,10 @@
       "name": "Timed Pull to Post Example",
       "description": "This is an example of a Timed Pull to Post Integration",
       "configuration": "",
+      "statusType": "Activated",
+      "tags": [
+        { "name": "example" }
+       ],
       "steps": [
         {
           "id": "5",

--- a/dao/src/test/java/com/redhat/ipaas/dao/DataManagerTest.java
+++ b/dao/src/test/java/com/redhat/ipaas/dao/DataManagerTest.java
@@ -25,6 +25,7 @@ import com.redhat.ipaas.model.integration.Integration;
 
 import org.junit.*;
 
+import java.io.IOException;
 import java.util.ArrayList;
 
 public class DataManagerTest {
@@ -95,11 +96,17 @@ public class DataManagerTest {
     }
     
     @Test
-    public void getIntegration() {
+    public void getIntegration() throws IOException {
         Integration integration = dataManager.fetch(Integration.KIND, "1");
         System.out.println(integration.getName());
         Assert.assertEquals("Example Integration", "Twitter to Salesforce Example", integration.getName());
         Assert.assertEquals(4, integration.getSteps().get().size());
+        
+        //making sure we can deserialize Enums such as StatusType
+        Integration int2 = new Integration.Builder().createFrom(integration).statusType(Integration.Type.Activated).build();
+        String json = Json.mapper().writeValueAsString(int2);
+        Integration int3 = Json.mapper().readValue(json, Integration.class);
+        Assert.assertEquals(int2.getStatusType(), int3.getStatusType());
     }
 
 }

--- a/dao/src/test/java/com/redhat/ipaas/dao/ReadApiClientDataTest.java
+++ b/dao/src/test/java/com/redhat/ipaas/dao/ReadApiClientDataTest.java
@@ -28,7 +28,6 @@ import com.redhat.ipaas.model.connection.ConnectorGroup;
 import com.redhat.ipaas.model.integration.Integration;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 
@@ -56,7 +55,7 @@ public class ReadApiClientDataTest {
 		Assert.assertEquals("{\"id\":\"label\",\"name\":\"label\"}", mdOut.getData());
 	}
 
-	@Test @Ignore
+	@Test
 	public void loadApiClientDataTest() throws IOException {
 		List<ModelData> modelDataList = new ReadApiClientData().readDataFromFile("com/redhat/ipaas/dao/deployment.json");
 		System.out.println("Found " + modelDataList.size() + " entities.");

--- a/dao/src/test/java/com/redhat/ipaas/dao/ReadApiClientDataTest.java
+++ b/dao/src/test/java/com/redhat/ipaas/dao/ReadApiClientDataTest.java
@@ -25,17 +25,26 @@ import com.redhat.ipaas.dao.init.ModelData;
 import com.redhat.ipaas.dao.init.ReadApiClientData;
 import com.redhat.ipaas.model.connection.Connector;
 import com.redhat.ipaas.model.connection.ConnectorGroup;
+import com.redhat.ipaas.model.integration.Integration;
+
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 
 public class ReadApiClientDataTest {
 
     private final static ObjectMapper mapper = Json.mapper();
-
+    
 	@Test
 	public void deserializeModelDataTest() throws IOException {
 
+	    Integration integrationIn = new Integration.Builder().statusType(Integration.Type.Activated).build();
+	    String integrationJson = mapper.writeValueAsString(integrationIn);
+	    System.out.println(integrationJson);
+	    Integration integrationOut = mapper.readValue(integrationJson, Integration.class);
+	    Assert.assertEquals(integrationIn.getStatusType(), integrationOut.getStatusType());
+	    
 		//serialize
 		ConnectorGroup cg = new ConnectorGroup.Builder().id("label").name("label").build();
 		ModelData mdIn = new ModelData(ConnectorGroup.KIND, mapper.writeValueAsString(cg));
@@ -47,7 +56,7 @@ public class ReadApiClientDataTest {
 		Assert.assertEquals("{\"id\":\"label\",\"name\":\"label\"}", mdOut.getData());
 	}
 
-	@Test
+	@Test @Ignore
 	public void loadApiClientDataTest() throws IOException {
 		List<ModelData> modelDataList = new ReadApiClientData().readDataFromFile("com/redhat/ipaas/dao/deployment.json");
 		System.out.println("Found " + modelDataList.size() + " entities.");

--- a/model/src/main/java/com/redhat/ipaas/model/integration/Integration.java
+++ b/model/src/main/java/com/redhat/ipaas/model/integration/Integration.java
@@ -32,9 +32,9 @@ public interface Integration extends WithId<Integration>, WithName, Serializable
 
     String KIND = "integration";
     
-    public enum Type {Activated, Deactivated};
+    public static enum Type {Activated, Deactivated};
     
-    public enum Phase {Pending, Running, Succeeded, Failed, Unknown};
+    public static enum Phase {Pending, Running, Succeeded, Failed, Unknown};
 
     /**
      *Required Labels
@@ -76,9 +76,9 @@ public interface Integration extends WithId<Integration>, WithName, Serializable
 
     Optional<String> getGitRepo();
 
-    Optional<Enum<Type>> getStatusType();
+    Optional<Type> getStatusType();
 
-    Optional<Enum<Phase>> getStatusPhase();
+    Optional<Phase> getStatusPhase();
 
     @Override
     default Integration withId(String id) {


### PR DESCRIPTION
This is so we can activate an integration by setting the StatusType to "Activated" on the integration.
When deployment starts it then sets the StatusPhase to Pending, and when up to Running, when not up to Failed, when successfully deactivated to Succeeded. There is also an Unknown Phase just in case. We could add a StatusMessage to report errors.