### PR TITLE
Fixes CircleCI deployment error.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -44,5 +44,5 @@ deployment:
     - curl -sSL https://github.com/openshift/origin/releases/download/v1.4.1/openshift-origin-client-tools-v1.4.1-3f9807a-linux-64bit.tar.gz | sudo tar xz -C /usr/bin --strip-components 1
     - oc login --server=${OPENSHIFT_APISERVER} --token=${OPENSHIFT_TOKEN}
     - oc project ipaas-staging
-    - oc import-image rhipaas/ipaas-rest:latest
+    - oc import-image --confirm=true rhipaas/ipaas-rest:latest
 


### PR DESCRIPTION
error: tag "latest" points to existing ImageStreamImage "ipaas-rest@sha256:2dba547c87f859dcd57e2e9ddf8fb38d4e1b03789f3d8c1aad9d11ae2f5a7cc8", it cannot be re-imported