### PR TITLE
IPAAS-273 Hide sensitive information

### DIFF
--- a/connector-catalog/src/main/java/com/redhat/ipaas/connector/catalog/ConnectorCatalog.java
+++ b/connector-catalog/src/main/java/com/redhat/ipaas/connector/catalog/ConnectorCatalog.java
@@ -32,6 +32,7 @@ public class ConnectorCatalog {
     private final MavenArtifactProvider maven;
 
     public ConnectorCatalog(ConnectorCatalogProperties props) {
+
         connectorCatalog = new DefaultCamelConnectorCatalog();
         camelCatalog = new DefaultCamelCatalog(true);
 

--- a/connector-catalog/src/main/java/com/redhat/ipaas/connector/catalog/ConnectorCatalog.java
+++ b/connector-catalog/src/main/java/com/redhat/ipaas/connector/catalog/ConnectorCatalog.java
@@ -61,7 +61,7 @@ public class ConnectorCatalog {
     }
 
     public String buildEndpointUri(String scheme, Map<String, String> options) throws URISyntaxException {
-        return camelCatalog.asEndpointUri(scheme, options, true);
+        return camelCatalog.asEndpointUri(scheme, options, false);
     }
 
 }

--- a/model/src/main/java/com/redhat/ipaas/model/connection/Connector.java
+++ b/model/src/main/java/com/redhat/ipaas/model/connection/Connector.java
@@ -19,6 +19,8 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.redhat.ipaas.model.Kind;
@@ -50,6 +52,28 @@ public interface Connector extends WithId<Connector>, WithName, Serializable {
     @Override
     default Connector withId(String id) {
         return new Builder().createFrom(this).id(id).build();
+    }
+
+    /**
+     * Filters the properties that the {@link Connector} considers sensitive / secret.
+     * @param properties        The specified configuration.
+     * @return                  A map with just the sensitive data.
+     */
+    default Map<String, String> filterSecrets(Map<String, String> properties) {
+        return filterSecrets(properties, e -> e.getValue());
+    }
+
+    /**
+     * Filters the properties that the {@link Connector} considers sensitive / secret.
+     * @param properties        The specified configuration.
+     * @param valueConverter    A {@link Function} that is applies to each {@link Map.Entry} of the configuration.
+     * @return                  A map with just the sensitive data.
+     */
+    default Map<String, String> filterSecrets(Map<String, String> properties, Function<Map.Entry<String, String>, String> valueConverter) {
+        return properties.entrySet()
+            .stream()
+            .filter(e -> this.getProperties() != null && this.getProperties().containsKey(e.getKey()) && this.getProperties().get(e.getKey()).getSecret())
+            .collect(Collectors.toMap(e -> e.getKey(), e -> valueConverter.apply(e)));
     }
 
     class Builder extends ImmutableConnector.Builder {

--- a/openshift/pom.xml
+++ b/openshift/pom.xml
@@ -54,6 +54,10 @@
       <artifactId>keycloak-spring-security-adapter</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+    </dependency>
 
     <!-- === Testing Dependencies ======================================================== -->
 

--- a/openshift/src/main/java/com/redhat/ipaas/openshift/CreateResourcesRequest.java
+++ b/openshift/src/main/java/com/redhat/ipaas/openshift/CreateResourcesRequest.java
@@ -15,10 +15,17 @@
  */
 package com.redhat.ipaas.openshift;
 
-public class OpenShiftServiceNoOp implements OpenShiftService {
 
-    @Override
-    public void createOpenShiftResources(CreateResourcesRequest request) {
-        // Empty no-op just for testing
-    }
+import org.immutables.value.Value;
+
+import java.util.Map;
+
+@Value.Immutable
+public interface CreateResourcesRequest {
+
+    String getName();
+    String getGitRepository();
+    String getWebhookSecret();
+    Map<String, String> getSecretData();
+
 }

--- a/openshift/src/main/java/com/redhat/ipaas/openshift/OpenShiftService.java
+++ b/openshift/src/main/java/com/redhat/ipaas/openshift/OpenShiftService.java
@@ -17,6 +17,6 @@ package com.redhat.ipaas.openshift;
 
 public interface OpenShiftService {
 
-    void createOpenShiftResources(String name, String gitRepo, String webhookSecret);
+    void createOpenShiftResources(CreateResourcesRequest request);
 
 }

--- a/project-generator/pom.xml
+++ b/project-generator/pom.xml
@@ -84,6 +84,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/project-generator/src/main/java/com/redhat/ipaas/project/converter/DefaultProjectGenerator.java
+++ b/project-generator/src/main/java/com/redhat/ipaas/project/converter/DefaultProjectGenerator.java
@@ -170,8 +170,8 @@ public class DefaultProjectGenerator implements ProjectGenerator {
         return YAML_OBJECT_MAPPER.writeValueAsBytes(funktion);
     }
 
-    private io.fabric8.funktion.model.steps.Step createEndpointStep(String camelConnector, Map<String, String> connectionConfiguredProperties, Map<String, String> configuredProperties) throws IOException, URISyntaxException {
-        Map<String, String> props = aggregate(connectionConfiguredProperties, configuredProperties);
+    private io.fabric8.funktion.model.steps.Step createEndpointStep(String camelConnector, Map<String, String> connectionConfiguredProperties, Map<String, String> stepConfiguredProperties) throws IOException, URISyntaxException {
+        Map<String, String> props = aggregate(connectionConfiguredProperties, stepConfiguredProperties);
 
         // TODO Remove this hack... when we can read endpointValues from connector schema then we should use those as initial properties.
         if ("periodic-timer".equals(camelConnector)) {

--- a/project-generator/src/main/java/com/redhat/ipaas/project/converter/DefaultProjectGenerator.java
+++ b/project-generator/src/main/java/com/redhat/ipaas/project/converter/DefaultProjectGenerator.java
@@ -22,6 +22,7 @@ import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
 import com.redhat.ipaas.connector.catalog.ConnectorCatalog;
 import com.redhat.ipaas.core.Json;
+import com.redhat.ipaas.model.connection.Connector;
 import com.redhat.ipaas.model.integration.Integration;
 import com.redhat.ipaas.model.integration.Step;
 import io.fabric8.funktion.model.Flow;
@@ -75,25 +76,27 @@ public class DefaultProjectGenerator implements ProjectGenerator {
     );
     */
     private final ConnectorCatalog connectorCatalog;
+    private final ProjectGeneratorProperties generatorProperties;
 
-    public DefaultProjectGenerator(ConnectorCatalog connectorCatalog) {
+    public DefaultProjectGenerator(ConnectorCatalog connectorCatalog, ProjectGeneratorProperties generatorProperties) {
         this.connectorCatalog = connectorCatalog;
+        this.generatorProperties = generatorProperties;
     }
 
     @Override
-    public Map<String, byte[]> generate(Integration integration) throws IOException {
-        integration.getSteps().ifPresent(steps -> {
+    public Map<String, byte[]> generate(GenerateProjectRequest request) throws IOException {
+        request.getIntegration().getSteps().ifPresent(steps -> {
             for (Step step : steps) {
                 step.getAction().ifPresent(action -> connectorCatalog.addConnector(action.getCamelConnectorGAV()));
             }
         });
 
         Map<String, byte[]> contents = new HashMap<>();
-        contents.put("README.md", generate(integration, readmeMustache));
-        contents.put("src/main/java/com/redhat/ipaas/example/Application.java", generate(integration, applicationJavaMustache));
-        contents.put("src/main/resources/application.yml", generate(integration, applicationYmlMustache));
-        contents.put("src/main/resources/funktion.yml", generateFlowYaml(integration));
-        contents.put("pom.xml", generatePom(integration));
+        contents.put("README.md", generate(request.getIntegration(), readmeMustache));
+        contents.put("src/main/java/com/redhat/ipaas/example/Application.java", generate(request.getIntegration(), applicationJavaMustache));
+        contents.put("src/main/resources/application.yml", generate(request.getIntegration(), applicationYmlMustache));
+        contents.put("src/main/resources/funktion.yml", generateFlowYaml(request));
+        contents.put("pom.xml", generatePom(request.getIntegration()));
 
         return contents;
     }
@@ -112,10 +115,7 @@ public class DefaultProjectGenerator implements ProjectGenerator {
                 }
             }
         });
-        return generate(
-            new IntegrationForPom(integration.getId().orElse(""), integration.getName(), integration.getDescription().orElse(null), connectors),
-            pomMustache
-        );
+        return generate(new IntegrationForPom(integration.getId().orElse(""), integration.getName(), integration.getDescription().orElse(null), connectors), pomMustache);
     }
 
 
@@ -136,15 +136,21 @@ public class DefaultProjectGenerator implements ProjectGenerator {
     }
     */
 
-    private byte[] generateFlowYaml(Integration integration) throws JsonProcessingException {
+    private byte[] generateFlowYaml(GenerateProjectRequest request) throws JsonProcessingException {
         Flow flow = new Flow();
-        integration.getSteps().ifPresent(steps -> {
+        request.getIntegration().getSteps().ifPresent(steps -> {
             for (Step step : steps) {
                 if (step.getStepKind().equals(StepKinds.ENDPOINT)) {
                     step.getAction().ifPresent(action -> {
                         step.getConnection().ifPresent(connection -> {
                             try {
-                                flow.addStep(createEndpointStep(action.getCamelConnectorPrefix(), connection.getConfiguredProperties(), step.getConfiguredProperties()));
+                                String connectorId = step.getConnection().get().getConnectorId().orElse(action.getConnectorId());
+                                if (!request.getConnectors().containsKey(connectorId)) {
+                                    throw new IllegalStateException("Connector:["+connectorId+"] not found.");
+                                }
+
+                                Connector connector = request.getConnectors().get(connectorId);
+                                flow.addStep(createEndpointStep(connector, action.getCamelConnectorPrefix(),  connection.getConfiguredProperties(), step.getConfiguredProperties()));
                             } catch (IOException | URISyntaxException e) {
                                 e.printStackTrace();
                             }
@@ -170,16 +176,24 @@ public class DefaultProjectGenerator implements ProjectGenerator {
         return YAML_OBJECT_MAPPER.writeValueAsBytes(funktion);
     }
 
-    private io.fabric8.funktion.model.steps.Step createEndpointStep(String camelConnector, Map<String, String> connectionConfiguredProperties, Map<String, String> stepConfiguredProperties) throws IOException, URISyntaxException {
-        Map<String, String> props = aggregate(connectionConfiguredProperties, stepConfiguredProperties);
-
+    private io.fabric8.funktion.model.steps.Step createEndpointStep(Connector connector, String camelConnectorPrefix, Map<String, String> connectionConfiguredProperties, Map<String, String> stepConfiguredProperties) throws IOException, URISyntaxException {
+        Map<String, String> properties = aggregate(connectionConfiguredProperties, stepConfiguredProperties);
+        Map<String, String> secrets = filterSecrets(connector, properties);
         // TODO Remove this hack... when we can read endpointValues from connector schema then we should use those as initial properties.
-        if ("periodic-timer".equals(camelConnector)) {
-            props.put("timerName", "every");
+        if ("periodic-timer".equals(camelConnectorPrefix)) {
+            properties.put("timerName", "every");
         }
 
-        String endpointUri = connectorCatalog.buildEndpointUri(camelConnector, props);
+        Map<String, String> maskedProperties = generatorProperties.isSecretMaskingEnabled() ? aggregate(properties, secrets) : properties;
+        String endpointUri = connectorCatalog.buildEndpointUri(camelConnectorPrefix, maskedProperties);
         return new Endpoint(endpointUri);
+    }
+
+    private Map<String, String> filterSecrets(Connector connector, Map<String, String> properties) {
+        return properties.entrySet()
+            .stream()
+            .filter(e -> connector.getProperties() != null && connector.getProperties().containsKey(e.getKey()) && connector.getProperties().get(e.getKey()).getSecret())
+            .collect(Collectors.toMap(e -> e.getKey(), e -> "{{" + e.getKey() + "}}"));
     }
 
     private static Map<String, String> aggregate(Map<String, String> ... maps) throws IOException {

--- a/project-generator/src/main/java/com/redhat/ipaas/project/converter/GenerateProjectRequest.java
+++ b/project-generator/src/main/java/com/redhat/ipaas/project/converter/GenerateProjectRequest.java
@@ -15,16 +15,19 @@
  */
 package com.redhat.ipaas.project.converter;
 
-
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.redhat.ipaas.model.connection.Connector;
 import com.redhat.ipaas.model.integration.Integration;
 
-import java.io.IOException;
+import org.immutables.value.Value;
+
 import java.util.Map;
 
+@Value.Immutable
+@JsonDeserialize(builder = Integration.Builder.class)
+public interface GenerateProjectRequest {
 
-public interface ProjectGenerator {
+    Integration getIntegration();
+    Map<String, Connector> getConnectors();
 
-    Map<String, byte[]> generate(GenerateProjectRequest request) throws IOException;
-
-    byte[] generatePom(Integration integration) throws IOException;
 }

--- a/project-generator/src/main/java/com/redhat/ipaas/project/converter/GenerateProjectRequest.java
+++ b/project-generator/src/main/java/com/redhat/ipaas/project/converter/GenerateProjectRequest.java
@@ -15,7 +15,6 @@
  */
 package com.redhat.ipaas.project.converter;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.redhat.ipaas.model.connection.Connector;
 import com.redhat.ipaas.model.integration.Integration;
 
@@ -24,7 +23,6 @@ import org.immutables.value.Value;
 import java.util.Map;
 
 @Value.Immutable
-@JsonDeserialize(builder = Integration.Builder.class)
 public interface GenerateProjectRequest {
 
     Integration getIntegration();

--- a/project-generator/src/main/java/com/redhat/ipaas/project/converter/ProjectGeneratorConfiguration.java
+++ b/project-generator/src/main/java/com/redhat/ipaas/project/converter/ProjectGeneratorConfiguration.java
@@ -16,15 +16,18 @@
 package com.redhat.ipaas.project.converter;
 
 import com.redhat.ipaas.connector.catalog.ConnectorCatalog;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@EnableConfigurationProperties(ProjectGeneratorProperties.class)
 public class ProjectGeneratorConfiguration {
 
     @Bean
-    public ProjectGenerator projectConverter(ConnectorCatalog connectorCatalog) {
-        return new DefaultProjectGenerator(connectorCatalog);
+    public ProjectGenerator projectConverter(ConnectorCatalog connectorCatalog, ProjectGeneratorProperties properties) {
+        return new DefaultProjectGenerator(connectorCatalog, properties);
     }
 
 }

--- a/project-generator/src/main/java/com/redhat/ipaas/project/converter/ProjectGeneratorProperties.java
+++ b/project-generator/src/main/java/com/redhat/ipaas/project/converter/ProjectGeneratorProperties.java
@@ -15,16 +15,18 @@
  */
 package com.redhat.ipaas.project.converter;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
-import com.redhat.ipaas.model.integration.Integration;
+@ConfigurationProperties("generator")
+public class ProjectGeneratorProperties {
 
-import java.io.IOException;
-import java.util.Map;
+    private Boolean secretMaskingEnabled = false;
 
+    public Boolean isSecretMaskingEnabled() {
+        return secretMaskingEnabled;
+    }
 
-public interface ProjectGenerator {
-
-    Map<String, byte[]> generate(GenerateProjectRequest request) throws IOException;
-
-    byte[] generatePom(Integration integration) throws IOException;
+    public void setSecretMaskingEnabled(Boolean secretMaskingEnabled) {
+        this.secretMaskingEnabled = secretMaskingEnabled;
+    }
 }

--- a/project-generator/src/main/resources/com/redhat/ipaas/project/converter/templates/application.yml.mustache
+++ b/project-generator/src/main/resources/com/redhat/ipaas/project/converter/templates/application.yml.mustache
@@ -1,3 +1,5 @@
+spring.application.name={{id}}
+spring.cloud.kubernetes.secrets.paths=/opt/integration/secrets.properties
 ## name of CamelContext
 camel.springboot.name={{id}}
 

--- a/project-generator/src/main/resources/com/redhat/ipaas/project/converter/templates/pom.xml.mustache
+++ b/project-generator/src/main/resources/com/redhat/ipaas/project/converter/templates/pom.xml.mustache
@@ -13,6 +13,7 @@
 
   <properties>
     <spring-boot.version>@spring-boot.version@</spring-boot.version>
+    <spring-cloud-kubernetes.version>@spring-cloud-kubernetes.version@</spring-cloud-kubernetes>
     <camel.version>@camel.version@</camel.version>
     <funktion.version>@funktion.version@</funktion.version>
   </properties>
@@ -81,6 +82,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>spring-cloud-kubernetes-bom</artifactId>
+        <version>${spring-cloud-kubernetes.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -111,6 +119,10 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>spring-cloud-kubernetes-core</artifactId>
     </dependency>
 
     <!-- Funktion runtime -->

--- a/project-generator/src/main/resources/com/redhat/ipaas/project/converter/templates/pom.xml.mustache
+++ b/project-generator/src/main/resources/com/redhat/ipaas/project/converter/templates/pom.xml.mustache
@@ -13,7 +13,7 @@
 
   <properties>
     <spring-boot.version>@spring-boot.version@</spring-boot.version>
-    <spring-cloud-kubernetes.version>@spring-cloud-kubernetes.version@</spring-cloud-kubernetes>
+    <spring-cloud-kubernetes.version>@spring-cloud-kubernetes.version@</spring-cloud-kubernetes.version>
     <camel.version>@camel.version@</camel.version>
     <funktion.version>@funktion.version@</funktion.version>
   </properties>

--- a/project-generator/src/test/java/com/redhat/ipaas/project/converter/DefaultProjectGeneratorTest.java
+++ b/project-generator/src/test/java/com/redhat/ipaas/project/converter/DefaultProjectGeneratorTest.java
@@ -82,13 +82,6 @@ public class DefaultProjectGeneratorTest {
         assertFileContents(files.get("pom.xml"), "test-pom.xml");
     }
 
-    private void assertFileContents(byte[] actualContents, String expectedFileName) throws Exception {
-        assertThat(new String(actualContents)).isEqualTo(
-            new String(Files.readAllBytes(
-                Paths.get(this.getClass().getResource(expectedFileName).toURI())
-            ), StandardCharsets.UTF_8)
-        );
-    }
 
     @Test
     public void testConverterWithPasswordMasking() throws Exception {
@@ -138,8 +131,17 @@ public class DefaultProjectGeneratorTest {
         assertFileContents(files.get("pom.xml"), "test-pull-push-pom.xml");
     }
 
+
+    private static void assertFileContents(byte[] actualContents, String expectedFileName) throws Exception {
+        assertThat(new String(actualContents)).isEqualTo(
+            new String(Files.readAllBytes(
+                Paths.get(DefaultProjectGeneratorTest.class.getResource(expectedFileName).toURI())
+            ), StandardCharsets.UTF_8)
+        );
+    }
+
     // Helper method to help constuct maps with concise syntax
-    private HashMap<String, ? extends String> map(Object... values) {
+    private static HashMap<String, ? extends String> map(Object... values) {
         HashMap<String, String> rc = new HashMap<String, String>();
         for (int i = 0; i + 1 < values.length; i += 2) {
             rc.put(values[i].toString(), values[i + 1].toString());

--- a/project-generator/src/test/java/com/redhat/ipaas/project/converter/DefaultProjectGeneratorTest.java
+++ b/project-generator/src/test/java/com/redhat/ipaas/project/converter/DefaultProjectGeneratorTest.java
@@ -48,8 +48,6 @@ public class DefaultProjectGeneratorTest {
     @Test
     public void testConvert() throws Exception {
 
-        Assume.assumeFalse(hasOrNeedsUrlEncoding(GrapeIvy.class.getResource("defaultGrapeConfig.xml").getFile()));
-
         Step step1 = new Step.Builder().stepKind("endpoint").connection(new Connection.Builder().configuredProperties(map()).build()).configuredProperties(map("period",5000)).action(new Action.Builder().camelConnectorPrefix("periodic-timer").camelConnectorGAV("com.redhat.ipaas:timer-connector:0.2.1").build()).build();
         Step step2 = new Step.Builder().stepKind("endpoint").connection(new Connection.Builder().configuredProperties(map()).build()).configuredProperties(map("httpUri", "http://localhost:8080/hello")).action(new Action.Builder().camelConnectorPrefix("http-get").camelConnectorGAV("com.redhat.ipaas:http-get-connector:0.2.1").build()).build();
         Step step3 = new Step.Builder().stepKind("log").configuredProperties(map("message", "Hello World! ${body}")).build();
@@ -81,7 +79,6 @@ public class DefaultProjectGeneratorTest {
 
     @Test
     public void testConvertFromJson() throws Exception {
-        Assume.assumeFalse(hasOrNeedsUrlEncoding(GrapeIvy.class.getResource("defaultGrapeConfig.xml").getFile()));
 
         JsonNode json = new ObjectMapper().readTree(this.getClass().getResourceAsStream("test-integration.json"));
         Map<String, byte[]> files = new DefaultProjectGenerator(new ConnectorCatalog(new ConnectorCatalogProperties())).generate(
@@ -92,10 +89,6 @@ public class DefaultProjectGeneratorTest {
         assertFileContents(files.get("src/main/resources/application.yml"), "test-pull-push-application.yml");
         assertFileContents(files.get("src/main/resources/funktion.yml"), "test-pull-push-funktion.yml");
         assertFileContents(files.get("pom.xml"), "test-pull-push-pom.xml");
-    }
-
-    private static Boolean hasOrNeedsUrlEncoding(String path) throws UnsupportedEncodingException {
-        return !path.equals(URLDecoder.decode(path, "UTF-8")) || !path.equals(URLEncoder.encode(path, "UTF-8"));
     }
 
     // Helper method to help constuct maps with concise syntax

--- a/project-generator/src/test/java/com/redhat/ipaas/project/converter/DefaultProjectGeneratorTest.java
+++ b/project-generator/src/test/java/com/redhat/ipaas/project/converter/DefaultProjectGeneratorTest.java
@@ -15,6 +15,7 @@
  */
 package com.redhat.ipaas.project.converter;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
@@ -22,17 +23,14 @@ import com.redhat.ipaas.connector.catalog.ConnectorCatalog;
 import com.redhat.ipaas.connector.catalog.ConnectorCatalogProperties;
 import com.redhat.ipaas.model.connection.Action;
 import com.redhat.ipaas.model.connection.Connection;
+import com.redhat.ipaas.model.connection.Connector;
 import com.redhat.ipaas.model.integration.Integration;
 import com.redhat.ipaas.model.integration.Step;
 
-import groovy.grape.GrapeIvy;
-
-import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Test;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.net.URLEncoder;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -45,23 +43,38 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class DefaultProjectGeneratorTest {
 
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new Jdk8Module());
+    private static final TypeReference<HashMap<String, Connector>> CONNECTOR_MAP_TYPE_REF = new TypeReference<HashMap<String, Connector>>() {
+    };
+
+    private Map<String, Connector> connectors = new HashMap<>();
+
+    @Before
+    public void setUp() throws IOException {
+        connectors.putAll(OBJECT_MAPPER.readValue(this.getClass().getResourceAsStream("test-connectors.json"), CONNECTOR_MAP_TYPE_REF));
+    }
+
     @Test
     public void testConvert() throws Exception {
-
-        Step step1 = new Step.Builder().stepKind("endpoint").connection(new Connection.Builder().configuredProperties(map()).build()).configuredProperties(map("period",5000)).action(new Action.Builder().camelConnectorPrefix("periodic-timer").camelConnectorGAV("com.redhat.ipaas:timer-connector:0.2.1").build()).build();
-        Step step2 = new Step.Builder().stepKind("endpoint").connection(new Connection.Builder().configuredProperties(map()).build()).configuredProperties(map("httpUri", "http://localhost:8080/hello")).action(new Action.Builder().camelConnectorPrefix("http-get").camelConnectorGAV("com.redhat.ipaas:http-get-connector:0.2.1").build()).build();
+        Step step1 = new Step.Builder().stepKind("endpoint").connection(new Connection.Builder().configuredProperties(map()).build()).configuredProperties(map("period",5000)).action(new Action.Builder().connectorId("timer").camelConnectorPrefix("periodic-timer").camelConnectorGAV("com.redhat.ipaas:timer-connector:0.2.1").build()).build();
+        Step step2 = new Step.Builder().stepKind("endpoint").connection(new Connection.Builder().configuredProperties(map()).build()).configuredProperties(map("httpUri", "http://localhost:8080/hello")).action(new Action.Builder().connectorId("http").camelConnectorPrefix("http-get").camelConnectorGAV("com.redhat.ipaas:http-get-connector:0.2.1").build()).build();
         Step step3 = new Step.Builder().stepKind("log").configuredProperties(map("message", "Hello World! ${body}")).build();
-        Step step4 = new Step.Builder().stepKind("endpoint").connection(new Connection.Builder().configuredProperties(Collections.emptyMap()).build()).configuredProperties(map("httpUri", "http://localhost:8080/bye")).action(new Action.Builder().camelConnectorPrefix("http-post").camelConnectorGAV("com.redhat.ipaas:http-post-connector:0.2.1").build()).build();
+        Step step4 = new Step.Builder().stepKind("endpoint").connection(new Connection.Builder().configuredProperties(Collections.emptyMap()).build()).configuredProperties(map("httpUri", "http://localhost:8080/bye")).action(new Action.Builder().connectorId("http").camelConnectorPrefix("http-post").camelConnectorGAV("com.redhat.ipaas:http-post-connector:0.2.1").build()).build();
 
-        Map<String, byte[]> files = new DefaultProjectGenerator(new ConnectorCatalog(new ConnectorCatalogProperties())).generate(
-            new Integration.Builder()
+        GenerateProjectRequest request = ImmutableGenerateProjectRequest
+            .builder()
+            .integration(new Integration.Builder()
                 .id("test-integration")
                 .name("Test Integration")
                 .description("This is a test integration!")
                 .gitRepo("https://ourgithhost.somewhere/test.git")
                 .steps( Arrays.asList(step1, step2, step3, step4))
-                .build()
-                                                                                                                               );
+                .build())
+            .connectors(connectors)
+            .build();
+
+        Map<String, byte[]> files = new DefaultProjectGenerator(new ConnectorCatalog(new ConnectorCatalogProperties()), new ProjectGeneratorProperties()).generate(request);
+
         assertFileContents(files.get("README.md"), "test-README.md");
         assertFileContents(files.get("src/main/java/com/redhat/ipaas/example/Application.java"), "test-Application.java");
         assertFileContents(files.get("src/main/resources/application.yml"), "test-application.yml");
@@ -78,12 +91,46 @@ public class DefaultProjectGeneratorTest {
     }
 
     @Test
+    public void testConverterWithPasswordMasking() throws Exception {
+        Step step1 = new Step.Builder().stepKind("endpoint").connection(new Connection.Builder().configuredProperties(map()).build()).configuredProperties(map("period",5000)).action(new Action.Builder().connectorId("timer").camelConnectorPrefix("periodic-timer").camelConnectorGAV("com.redhat.ipaas:timer-connector:0.2.1").build()).build();
+        Step step2 = new Step.Builder().stepKind("endpoint").connection(new Connection.Builder().configuredProperties(map()).build()).configuredProperties(map("httpUri", "http://localhost:8080/hello", "username", "admin", "password", "admin")).action(new Action.Builder().connectorId("http").camelConnectorPrefix("http-get").camelConnectorGAV("com.redhat.ipaas:http-get-connector:0.2.1").build()).build();
+
+        GenerateProjectRequest request = ImmutableGenerateProjectRequest
+            .builder()
+            .integration(new Integration.Builder()
+                .id("test-integration")
+                .name("Test Integration")
+                .description("This is a test integration!")
+                .gitRepo("https://ourgithhost.somewhere/test.git")
+                .steps( Arrays.asList(step1, step2))
+                .build())
+            .connectors(connectors)
+            .build();
+
+        ProjectGeneratorProperties generatorProperties = new ProjectGeneratorProperties();
+        generatorProperties.setSecretMaskingEnabled(true);
+
+        Map<String, byte[]> files = new DefaultProjectGenerator(new ConnectorCatalog(new ConnectorCatalogProperties()), generatorProperties).generate(request);
+
+
+        assertFileContents(files.get("src/main/resources/application.yml"), "test-application.yml");
+        assertFileContents(files.get("src/main/resources/funktion.yml"), "test-funktion-with-secrets.yml");
+    }
+
+
+    @Test
     public void testConvertFromJson() throws Exception {
 
         JsonNode json = new ObjectMapper().readTree(this.getClass().getResourceAsStream("test-integration.json"));
-        Map<String, byte[]> files = new DefaultProjectGenerator(new ConnectorCatalog(new ConnectorCatalogProperties())).generate(
-            new ObjectMapper().registerModule(new Jdk8Module()).readValue(json.get("data").toString(), Integration.class)
-                                                                                                                               );
+
+        GenerateProjectRequest request = ImmutableGenerateProjectRequest
+            .builder()
+            .integration(new ObjectMapper().registerModule(new Jdk8Module()).readValue(json.get("data").toString(), Integration.class))
+            .connectors(connectors)
+            .build();
+
+        Map<String, byte[]> files = new DefaultProjectGenerator(new ConnectorCatalog(new ConnectorCatalogProperties()), new ProjectGeneratorProperties()).generate(request);
+
         assertFileContents(files.get("README.md"), "test-pull-push-README.md");
         assertFileContents(files.get("src/main/java/com/redhat/ipaas/example/Application.java"), "test-Application.java");
         assertFileContents(files.get("src/main/resources/application.yml"), "test-pull-push-application.yml");

--- a/project-generator/src/test/resources/com/redhat/ipaas/project/converter/test-application.yml
+++ b/project-generator/src/test/resources/com/redhat/ipaas/project/converter/test-application.yml
@@ -1,3 +1,5 @@
+spring.application.name=test-integration
+spring.cloud.kubernetes.secrets.paths=/opt/integration/secrets.properties
 ## name of CamelContext
 camel.springboot.name=test-integration
 

--- a/project-generator/src/test/resources/com/redhat/ipaas/project/converter/test-connectors.json
+++ b/project-generator/src/test/resources/com/redhat/ipaas/project/converter/test-connectors.json
@@ -1,0 +1,43 @@
+{
+  "http": {
+    "kind": "Connector",
+      "id": "http",
+      "name": "Http",
+      "description": "Http Connector",
+      "icon": "http",
+      "properties": {
+        "username": {
+          "kind": "property",
+          "displayName": "Username",
+          "group": "security",
+          "label": "security",
+          "required": false,
+          "type": "string",
+          "javaType": "java.lang.String",
+          "deprecated": false,
+          "secret": true,
+          "description": "The username"
+        },
+        "password": {
+          "kind": "property",
+          "displayName": "Password",
+          "group": "security",
+          "label": "security",
+          "required": false,
+          "type": "string",
+          "javaType": "java.lang.String",
+          "deprecated": false,
+          "secret": true,
+          "description": "The password"
+        }
+      }
+  },
+  "timer": {
+    "kind": "Connector",
+      "id": "timer",
+      "name": "Timer",
+      "description": "Timer Connector",
+      "icon": "fa-puzzle-piece",
+      "properties": {}
+    }
+}

--- a/project-generator/src/test/resources/com/redhat/ipaas/project/converter/test-funktion-with-secrets.yml
+++ b/project-generator/src/test/resources/com/redhat/ipaas/project/converter/test-funktion-with-secrets.yml
@@ -4,4 +4,4 @@ flows:
   - kind: endpoint
     uri: periodic-timer:every?period=5000
   - kind: endpoint
-    uri: http-get:http://localhost:8080/hello?password=%7B%7Bpassword%7D%7D&username=%7B%7Busername%7D%7D
+    uri: http-get:http://localhost:8080/hello?password={{password}}&username={{username}}

--- a/project-generator/src/test/resources/com/redhat/ipaas/project/converter/test-funktion-with-secrets.yml
+++ b/project-generator/src/test/resources/com/redhat/ipaas/project/converter/test-funktion-with-secrets.yml
@@ -1,0 +1,7 @@
+---
+flows:
+- steps:
+  - kind: endpoint
+    uri: periodic-timer:every?period=5000
+  - kind: endpoint
+    uri: http-get:http://localhost:8080/hello?password=%7B%7Bpassword%7D%7D&username=%7B%7Busername%7D%7D

--- a/project-generator/src/test/resources/com/redhat/ipaas/project/converter/test-integration.json
+++ b/project-generator/src/test/resources/com/redhat/ipaas/project/converter/test-integration.json
@@ -19,6 +19,7 @@
           "id": 4
         },
         "action": {
+          "connectorId": "http",
           "description": "Set a timer that fires at intervals that you specify",
           "properties": {
             "period": {
@@ -56,6 +57,7 @@
           "id": 3
         },
         "action": {
+          "connectorId": "http",
           "description": "Call a service that is internal (within your company) or external (on the internet) by specifying the service's URL",
           "properties": {
             "httpUri": {
@@ -101,6 +103,7 @@
           "id": 3
         },
         "action": {
+          "connectorId": "http",
           "description": "Call a service that is internal (within your company) or external (on the internet) by specifying the service's URL",
           "properties": {
             "httpUri": {

--- a/project-generator/src/test/resources/com/redhat/ipaas/project/converter/test-pom.xml
+++ b/project-generator/src/test/resources/com/redhat/ipaas/project/converter/test-pom.xml
@@ -13,6 +13,7 @@
 
   <properties>
     <spring-boot.version>1.5.2.RELEASE</spring-boot.version>
+    <spring-cloud-kubernetes.version>0.1.6</spring-cloud-kubernetes>
     <camel.version>2.19.0-SNAPSHOT</camel.version>
     <funktion.version>1.1.55</funktion.version>
   </properties>
@@ -81,6 +82,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>spring-cloud-kubernetes-bom</artifactId>
+        <version>${spring-cloud-kubernetes.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -119,6 +127,10 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>spring-cloud-kubernetes-core</artifactId>
     </dependency>
 
     <!-- Funktion runtime -->

--- a/project-generator/src/test/resources/com/redhat/ipaas/project/converter/test-pom.xml
+++ b/project-generator/src/test/resources/com/redhat/ipaas/project/converter/test-pom.xml
@@ -13,8 +13,8 @@
 
   <properties>
     <spring-boot.version>1.5.2.RELEASE</spring-boot.version>
-    <spring-cloud-kubernetes.version>0.1.6</spring-cloud-kubernetes.version>
-    <camel.version>2.19.0-SNAPSHOT</camel.version>
+    <spring-cloud-kubernetes.version>0.1.5</spring-cloud-kubernetes.version>
+    <camel.version>2.19.0.fuse-000020</camel.version>
     <funktion.version>1.1.55</funktion.version>
   </properties>
 
@@ -71,21 +71,21 @@
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring-boot.version}</version>
+        <version>1.5.2.RELEASE</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-boot-dependencies</artifactId>
-        <version>${camel.version}</version>
+        <version>2.19.0.fuse-000020</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.fabric8</groupId>
         <artifactId>spring-cloud-kubernetes-bom</artifactId>
-        <version>${spring-cloud-kubernetes.version}</version>
+        <version>0.1.5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -137,19 +137,19 @@
     <dependency>
       <groupId>io.fabric8.funktion</groupId>
       <artifactId>funktion-model</artifactId>
-      <version>${funktion.version}</version>
+      <version>1.1.55</version>
     </dependency>
     <dependency>
       <groupId>io.fabric8.funktion</groupId>
       <artifactId>funktion-runtime</artifactId>
-      <version>${funktion.version}</version>
+      <version>1.1.55</version>
     </dependency>
 
     <!-- testing -->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-test</artifactId>
-      <version>${camel.version}</version>
+      <version>2.19.0.fuse-000020</version>
       <scope>test</scope>
     </dependency>
 
@@ -161,7 +161,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${spring-boot.version}</version>
+        <version>1.5.2.RELEASE</version>
         <executions>
           <execution>
             <goals>

--- a/project-generator/src/test/resources/com/redhat/ipaas/project/converter/test-pom.xml
+++ b/project-generator/src/test/resources/com/redhat/ipaas/project/converter/test-pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <spring-boot.version>1.5.2.RELEASE</spring-boot.version>
-    <spring-cloud-kubernetes.version>0.1.6</spring-cloud-kubernetes>
+    <spring-cloud-kubernetes.version>0.1.6</spring-cloud-kubernetes.version>
     <camel.version>2.19.0-SNAPSHOT</camel.version>
     <funktion.version>1.1.55</funktion.version>
   </properties>

--- a/project-generator/src/test/resources/com/redhat/ipaas/project/converter/test-pull-push-application.yml
+++ b/project-generator/src/test/resources/com/redhat/ipaas/project/converter/test-pull-push-application.yml
@@ -1,3 +1,5 @@
+spring.application.name=2
+spring.cloud.kubernetes.secrets.paths=/opt/integration/secrets.properties
 ## name of CamelContext
 camel.springboot.name=2
 

--- a/project-generator/src/test/resources/com/redhat/ipaas/project/converter/test-pull-push-pom.xml
+++ b/project-generator/src/test/resources/com/redhat/ipaas/project/converter/test-pull-push-pom.xml
@@ -13,6 +13,7 @@
 
   <properties>
     <spring-boot.version>1.5.2.RELEASE</spring-boot.version>
+    <spring-cloud-kubernetes.version>0.1.6</spring-cloud-kubernetes>
     <camel.version>2.19.0-SNAPSHOT</camel.version>
     <funktion.version>1.1.55</funktion.version>
   </properties>
@@ -81,6 +82,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>spring-cloud-kubernetes-bom</artifactId>
+        <version>${spring-cloud-kubernetes.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -119,6 +127,10 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>spring-cloud-kubernetes-core</artifactId>
     </dependency>
 
     <!-- Funktion runtime -->

--- a/project-generator/src/test/resources/com/redhat/ipaas/project/converter/test-pull-push-pom.xml
+++ b/project-generator/src/test/resources/com/redhat/ipaas/project/converter/test-pull-push-pom.xml
@@ -13,8 +13,8 @@
 
   <properties>
     <spring-boot.version>1.5.2.RELEASE</spring-boot.version>
-    <spring-cloud-kubernetes.version>0.1.6</spring-cloud-kubernetes.version>
-    <camel.version>2.19.0-SNAPSHOT</camel.version>
+    <spring-cloud-kubernetes.version>0.1.5</spring-cloud-kubernetes.version>
+    <camel.version>2.19.0.fuse-000020</camel.version>
     <funktion.version>1.1.55</funktion.version>
   </properties>
 
@@ -71,21 +71,21 @@
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring-boot.version}</version>
+        <version>1.5.2.RELEASE</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-boot-dependencies</artifactId>
-        <version>${camel.version}</version>
+        <version>2.19.0.fuse-000020</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.fabric8</groupId>
         <artifactId>spring-cloud-kubernetes-bom</artifactId>
-        <version>${spring-cloud-kubernetes.version}</version>
+        <version>0.1.5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -137,19 +137,19 @@
     <dependency>
       <groupId>io.fabric8.funktion</groupId>
       <artifactId>funktion-model</artifactId>
-      <version>${funktion.version}</version>
+      <version>1.1.55</version>
     </dependency>
     <dependency>
       <groupId>io.fabric8.funktion</groupId>
       <artifactId>funktion-runtime</artifactId>
-      <version>${funktion.version}</version>
+      <version>1.1.55</version>
     </dependency>
 
     <!-- testing -->
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-test</artifactId>
-      <version>${camel.version}</version>
+      <version>2.19.0.fuse-000020</version>
       <scope>test</scope>
     </dependency>
 
@@ -161,7 +161,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${spring-boot.version}</version>
+        <version>1.5.2.RELEASE</version>
         <executions>
           <execution>
             <goals>

--- a/project-generator/src/test/resources/com/redhat/ipaas/project/converter/test-pull-push-pom.xml
+++ b/project-generator/src/test/resources/com/redhat/ipaas/project/converter/test-pull-push-pom.xml
@@ -45,7 +45,25 @@
       <name>jcenter</name>
       <url>https://jcenter.bintray.com</url>
     </repository>
+    <repository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>jboss.ea</id>
+      <name>JBoss EA</name>
+      <url>https://repository.jboss.org/nexus/content/groups/ea</url>
+    </repository>
   </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>jboss.ea</id>
+      <name>JBoss EA</name>
+      <url>https://repository.jboss.org/nexus/content/groups/ea</url>
+    </pluginRepository>
+  </pluginRepositories>
 
   <dependencyManagement>
     <dependencies>

--- a/project-generator/src/test/resources/com/redhat/ipaas/project/converter/test-pull-push-pom.xml
+++ b/project-generator/src/test/resources/com/redhat/ipaas/project/converter/test-pull-push-pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <spring-boot.version>1.5.2.RELEASE</spring-boot.version>
-    <spring-cloud-kubernetes.version>0.1.6</spring-cloud-kubernetes>
+    <spring-cloud-kubernetes.version>0.1.6</spring-cloud-kubernetes.version>
     <camel.version>2.19.0-SNAPSHOT</camel.version>
     <funktion.version>1.1.55</funktion.version>
   </properties>

--- a/rest/src/main/java/com/redhat/ipaas/rest/v1/handler/integration/IntegrationHandler.java
+++ b/rest/src/main/java/com/redhat/ipaas/rest/v1/handler/integration/IntegrationHandler.java
@@ -16,6 +16,7 @@
 package com.redhat.ipaas.rest.v1.handler.integration;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.math.BigInteger;
 import java.util.Date;
 import java.util.Map;
@@ -31,12 +32,16 @@ import com.redhat.ipaas.github.GitHubService;
 import com.redhat.ipaas.model.Kind;
 import com.redhat.ipaas.model.connection.Connector;
 import com.redhat.ipaas.model.integration.Integration;
+import com.redhat.ipaas.model.integration.Step;
+import com.redhat.ipaas.openshift.ImmutableCreateResourcesRequest;
 import com.redhat.ipaas.openshift.OpenShiftService;
 import com.redhat.ipaas.project.converter.GenerateProjectRequest;
 import com.redhat.ipaas.project.converter.ImmutableGenerateProjectRequest;
 import com.redhat.ipaas.project.converter.ProjectGenerator;
 import com.redhat.ipaas.rest.v1.handler.BaseHandler;
 import com.redhat.ipaas.rest.v1.operations.*;
+
+import io.fabric8.funktion.model.StepKinds;
 import io.swagger.annotations.Api;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -120,7 +125,7 @@ public class IntegrationHandler extends BaseHandler implements Lister<Integratio
             GenerateProjectRequest request = ImmutableGenerateProjectRequest
                 .builder()
                 .integration(integrationWithGitRepoName)
-                .connectors(getDataManager().fetchAll(Connector.class).getItems().stream().collect(Collectors.toMap(o -> o.getId().get(), o -> o)))
+                .connectors(connectorsMap())
                 .build();
 
             Map<String, byte[]> fileContents = projectConverter.generate(request);
@@ -161,7 +166,41 @@ public class IntegrationHandler extends BaseHandler implements Lister<Integratio
         return UUID.randomUUID().toString();
     }
 
-    private void ensureOpenShiftResources(Integration integration, String secret) {
-        integration.getGitRepo().ifPresent(gitRepo -> openShiftService.createOpenShiftResources(integration.getName(), gitRepo, secret));
+    private Map<String, Connector> connectorsMap() {
+        return getDataManager().fetchAll(Connector.class).getItems().stream().collect(Collectors.toMap(o -> o.getId().get(), o -> o));
+    }
+
+    private void ensureOpenShiftResources(Integration integration, String webHookSecret) {
+        integration.getGitRepo().ifPresent(gitRepo -> openShiftService.createOpenShiftResources(ImmutableCreateResourcesRequest.builder()
+            .name(integration.getName())
+            .gitRepository(gitRepo)
+            .webhookSecret(webHookSecret)
+            .secretData(extractSecretsFrom(integration))
+            .build()));
+    }
+
+    private Map<String, String> extractSecretsFrom(Integration integration) {
+        Map<String, String> secrets = new HashMap<>();
+        Map<String, Connector> connectorMap = connectorsMap();
+
+        integration.getSteps().ifPresent(steps -> {
+            for (Step step : steps) {
+                if (step.getStepKind().equals(StepKinds.ENDPOINT)) {
+                    step.getAction().ifPresent(action -> {
+                        step.getConnection().ifPresent(connection -> {
+                                String connectorId = step.getConnection().get().getConnectorId().orElse(action.getConnectorId());
+                                if (!connectorMap.containsKey(connectorId)) {
+                                    throw new IllegalStateException("Connector:[" + connectorId + "] not found.");
+                                }
+                                Connector connector = connectorMap.get(connectorId);
+                                secrets.putAll(connector.filterSecrets(connection.getConfiguredProperties()));
+                                secrets.putAll(connector.filterSecrets(step.getConfiguredProperties()));
+                        });
+                    });
+                    continue;
+                }
+            }
+        });
+        return secrets;
     }
 }

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -60,7 +60,7 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <configuration>
-          <jvmArguments>-server -Xms256m -Xmx512m</jvmArguments>
+          <jvmArguments>-server -Xms512m -Xmx1024m -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005</jvmArguments>
         </configuration>
         <executions>
           <execution>

--- a/runtime/src/main/resources/application.yml
+++ b/runtime/src/main/resources/application.yml
@@ -79,3 +79,6 @@ github:
 verifier:
   kind: service
   service: ipaas-verifier
+
+generator:
+  secretMaskingEnabled: false


### PR DESCRIPTION
This pull requests modifies the ProjectGenerator to optionally *(its configurable)* mask secrets.

Masked secrets passed as placeholders in the URL wrapped around double squiggles, so that it can be replaced on runtime by spring-boot via `spring-cloud-kubernetes-config`.

TODO:
- also mask data inside the database (?).
