### PR TITLE
[whitespace] Remove whitespace from dummy json data

### DIFF
--- a/dao/src/main/resources/com/redhat/ipaas/dao/deployment.json
+++ b/dao/src/main/resources/com/redhat/ipaas/dao/deployment.json
@@ -19,7 +19,7 @@
           "secret": true,
           "description": "The access token"
         },
-        " accessTokenSecret": {
+        "accessTokenSecret": {
           "kind": "property",
           "displayName": "Access Token Secret",
           "group": "security",
@@ -31,7 +31,7 @@
           "secret": true,
           "description": "The access token secret"
         },
-        " consumerKey": {
+        "consumerKey": {
           "kind": "property",
           "displayName": "Consumer Key",
           "group": "security",
@@ -43,7 +43,7 @@
           "secret": true,
           "description": "The consumer key"
         },
-        " consumerSecret": {
+        "consumerSecret": {
           "kind": "property",
           "displayName": "Consumer Secret",
           "group": "security",


### PR DESCRIPTION
spaces around property names break e2e tests.
```html
<input class="form-control ng-untouched ng-pristine ng-valid" autocomplete="on" 
  name=" accessTokenSecret" placeholder="The access token secret" spellcheck="false"
  type="password" id=" accessTokenSecret">
```