### PR TITLE
fix(github): Fix generated webhook URL

### DIFF
--- a/openshift/src/main/java/com/redhat/ipaas/openshift/OpenShiftConfigurationProperties.java
+++ b/openshift/src/main/java/com/redhat/ipaas/openshift/OpenShiftConfigurationProperties.java
@@ -18,8 +18,10 @@ package com.redhat.ipaas.openshift;
 import io.fabric8.openshift.client.OpenShiftConfig;
 import io.fabric8.openshift.client.OpenShiftConfigBuilder;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 @ConfigurationProperties("openshift")
+@Validated
 public class OpenShiftConfigurationProperties {
 
     public static final String SERVICE_CA_CERT_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt";
@@ -32,7 +34,7 @@ public class OpenShiftConfigurationProperties {
 
     private String builderImage = "fabric8/s2i-java:2.0.0";
 
-    private String openshiftApiBaseUrl;
+    private String apiBaseUrl;
 
     private String namespace;
 
@@ -66,12 +68,12 @@ public class OpenShiftConfigurationProperties {
         this.builderImage = builderImage;
     }
 
-    public String getOpenshiftApiBaseUrl() {
-        return openshiftApiBaseUrl;
+    public String getApiBaseUrl() {
+        return apiBaseUrl;
     }
 
-    public void setOpenshiftApiBaseUrl(String openshiftApiBaseUrl) {
-        this.openshiftApiBaseUrl = openshiftApiBaseUrl;
+    public void setApiBaseUrl(String apiBaseUrl) {
+        this.apiBaseUrl = apiBaseUrl;
     }
 
     public String getNamespace() {

--- a/openshift/src/main/java/com/redhat/ipaas/openshift/OpenShiftServiceImpl.java
+++ b/openshift/src/main/java/com/redhat/ipaas/openshift/OpenShiftServiceImpl.java
@@ -21,7 +21,6 @@ import com.redhat.ipaas.core.Tokens;
 
 import io.fabric8.kubernetes.client.RequestConfig;
 import io.fabric8.kubernetes.client.RequestConfigBuilder;
-import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.DeploymentConfigStatus;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
@@ -115,7 +114,7 @@ public class OpenShiftServiceImpl implements OpenShiftService {
     @Override
     public String getGitHubWebHookUrl(OpenShiftDeployment d, String secret) {
         return String.format("%s/namespaces/%s/buildconfigs/%s/webhooks/%s/github",
-                             config.getOpenshiftApiBaseUrl(), config.getNamespace(), Names.sanitize(d.getName()), secret);
+                             config.getApiBaseUrl(), config.getNamespace(), Names.sanitize(d.getName()), secret);
     }
 
     private int nullSafe(Integer nr) {


### PR DESCRIPTION
Ensure the generated webhook URL contains a valid hostname for the OpenShift API server.

Fixes #346