### PR TITLE
Integration Model revisited and updated

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -26,4 +26,4 @@ coverage:
 comment:
   layout: "header, diff, tree, sunburst"
   require_changes: true
-   
+

--- a/controllers/src/main/java/io/syndesis/controllers/integration/NoopHandlerProvider.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/NoopHandlerProvider.java
@@ -23,27 +23,34 @@ import java.util.Set;
 
 import io.syndesis.model.integration.Integration;
 
+import io.syndesis.model.integration.IntegrationRevision;
+import io.syndesis.model.integration.IntegrationState;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 @Component
 @ConditionalOnProperty(value = "controllers.integration.enabled", havingValue = "noop")
-public class NoopHandlerProvider implements StatusChangeHandlerProvider.StatusChangeHandler, StatusChangeHandlerProvider {
+public class NoopHandlerProvider implements StatusChangeHandler, StatusChangeHandlerProvider {
 
-    public Set<Integration.Status> getTriggerStatuses() {
+    public Set<IntegrationState> getTriggerStatuses() {
         return Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-            Integration.Status.Activated,
-            Integration.Status.Deactivated,
-            Integration.Status.Deleted)));
+            IntegrationState.Active,
+            IntegrationState.Inactive,
+            IntegrationState.Undeployed)));
     }
 
     @Override
-    public StatusUpdate execute(Integration integration) {
+    public StatusUpdate execute(Integration integration, IntegrationRevision revision) {
         return null;
     }
 
     @Override
-    public List<StatusChangeHandler> getStatusChangeHandlers() {
+    public List<StatusChangeHandler> getDraftStatusChangeHandlers() {
+        return Collections.singletonList(this);
+    }
+
+    @Override
+    public List<StatusChangeHandler> getDeployedStatusChangeHandlers() {
         return Collections.singletonList(this);
     }
 }

--- a/controllers/src/main/java/io/syndesis/controllers/integration/StatusChangeHandler.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/StatusChangeHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2016 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,12 +16,19 @@
 
 package io.syndesis.controllers.integration;
 
-import java.util.List;
+import io.syndesis.model.integration.Integration;
+import io.syndesis.model.integration.IntegrationRevision;
+import io.syndesis.model.integration.IntegrationState;
 
-public interface StatusChangeHandlerProvider {
+import java.util.Set;
 
-    List<StatusChangeHandler> getDraftStatusChangeHandlers();
+/**
+ *
+ */
+public interface StatusChangeHandler {
 
-    List<StatusChangeHandler> getDeployedStatusChangeHandlers();
+    Set<IntegrationState> getTriggerStatuses();
+
+    StatusUpdate execute(Integration model, IntegrationRevision revision);
 
 }

--- a/controllers/src/main/java/io/syndesis/controllers/integration/StatusUpdate.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/StatusUpdate.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.controllers.integration;
+
+import io.syndesis.model.integration.IntegrationState;
+
+import java.util.List;
+
+public class StatusUpdate {
+
+    private Integer version;
+    private IntegrationState state;
+    private String statusMessage;
+    private List<String> stepsPerformed;
+
+    public StatusUpdate(Integer version, IntegrationState state, String statusMessage, List<String> stepsPerformed) {
+        this.version = version;
+        this.state = state;
+        this.statusMessage = statusMessage;
+        this.stepsPerformed = stepsPerformed;
+    }
+
+    public StatusUpdate(Integer version, IntegrationState state, String statusMessage) {
+        this(version, state, statusMessage, null);
+    }
+
+    public StatusUpdate(Integer version, IntegrationState state) {
+        this(version, state, null, null);
+    }
+
+    public StatusUpdate(Integer version, IntegrationState state, List<String> stepsPerformed) {
+        this(version, state, null, stepsPerformed != null && !stepsPerformed.isEmpty() ? stepsPerformed : null);
+    }
+
+    public Integer getVesion() {
+        return version;
+    }
+
+    public IntegrationState getState() {
+        return state;
+    }
+
+    public String getStatusMessage() {
+        return statusMessage;
+    }
+
+    public List<String> getStepsPerformed() {
+        return stepsPerformed;
+    }
+
+    public StatusUpdate withError(Throwable t) {
+        return new StatusUpdate(version, IntegrationState.Error, t.getMessage());
+    }
+}

--- a/controllers/src/main/java/io/syndesis/controllers/integration/online/ActivateHandler.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/online/ActivateHandler.java
@@ -15,7 +15,20 @@
  */
 package io.syndesis.controllers.integration.online;
 
-import io.syndesis.controllers.integration.StatusChangeHandlerProvider;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import io.syndesis.controllers.integration.StatusChangeHandler;
+import io.syndesis.controllers.integration.StatusUpdate;
 import io.syndesis.core.Names;
 import io.syndesis.core.SyndesisServerException;
 import io.syndesis.core.Tokens;
@@ -24,6 +37,8 @@ import io.syndesis.github.GitHubService;
 import io.syndesis.integration.model.steps.Endpoint;
 import io.syndesis.model.connection.Connector;
 import io.syndesis.model.integration.Integration;
+import io.syndesis.model.integration.IntegrationRevision;
+import io.syndesis.model.integration.IntegrationState;
 import io.syndesis.model.integration.Step;
 import io.syndesis.openshift.ImmutableOpenShiftDeployment;
 import io.syndesis.openshift.OpenShiftDeployment;
@@ -34,18 +49,7 @@ import org.eclipse.egit.github.core.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-public class ActivateHandler implements StatusChangeHandlerProvider.StatusChangeHandler {
+public class ActivateHandler implements StatusChangeHandler {
 
     // Step used which should be performed only once per integration
     /* default */ static final String STEP_GITHUB = "github-setup";
@@ -66,29 +70,45 @@ public class ActivateHandler implements StatusChangeHandlerProvider.StatusChange
         this.projectConverter = projectConverter;
     }
 
-    @Override
-    public Set<Integration.Status> getTriggerStatuses() {
-        return Collections.singleton(Integration.Status.Activated);
+    public Set<IntegrationState> getTriggerStatuses() {
+        return Collections.singleton(IntegrationState.Active);
     }
 
-    @Override
-    public StatusUpdate execute(Integration integration) {
-        if (!integration.getToken().isPresent()) {
-            return new StatusUpdate(integration.getCurrentStatus().orElse(null), "No token present");
-        }
 
+    /**
+     *
+     * @param integration
+     * @param revision
+     * @return
+     */
+    @Override
+    public StatusUpdate execute(Integration integration, IntegrationRevision revision) {
+        //TODO: This is clearly wrong, we need something better than that.
+        Integer version = revision.getVersion().orElse(
+            integration.getRevisions()
+                .stream()
+                .map(i -> i.getVersion().orElse(0))
+                .reduce(Integer::max)
+                .orElse(0) + 1);
+
+        IntegrationRevision versionedRevision = revision.withVersion(version);
+
+        if (!integration.getToken().isPresent()) {
+            return new StatusUpdate(version, versionedRevision.getCurrentState(), "No token present");
+        }
 
         if (isTokenExpired(integration)) {
             LOG.info("{} : Token is expired", getLabel(integration));
-            return new StatusUpdate(integration.getCurrentStatus().orElse(null), "Token is expired");
+            return new StatusUpdate(version, versionedRevision.getCurrentState(), "Token is expired");
         }
         String token = storeToken(integration);
 
-        Properties applicationProperties = extractApplicationPropertiesFrom(integration);
+        Properties applicationProperties = extractApplicationPropertiesFrom(versionedRevision);
 
         OpenShiftDeployment deployment = OpenShiftDeployment
             .builder()
             .name(integration.getName())
+            .revisionNumber(version)
             .replicas(1)
             .token(token)
             .applicationProperties(applicationProperties)
@@ -97,15 +117,15 @@ public class ActivateHandler implements StatusChangeHandlerProvider.StatusChange
         String secret = createSecret();
 
         // TODO: Verify Token and refresh if expired ....
-
         List<String> stepsPerformed = integration.getStepsDone().orElse(new ArrayList<>());
         try {
             String gitCloneUrl = null;
             if (!stepsPerformed.contains(STEP_GITHUB)) {
                 User gitHubUser = getGitHubUser();
                 String username = gitHubUser.getLogin();
+                //TODO: Possibly the is something that want to do for every new revision.
                 LOG.info("{} : Looked up GitHub user {}", getLabel(integration), username);
-                Map<String, byte[]> projectFiles = createProjectFiles(username, integration);
+                Map<String, byte[]> projectFiles = createProjectFiles(username, integration, versionedRevision);
                 LOG.info("{} : Created project files", getLabel(integration));
 
                 gitCloneUrl = ensureGitHubSetup(integration, gitHubUser, getWebHookUrl(deployment, secret), projectFiles);
@@ -123,13 +143,19 @@ public class ActivateHandler implements StatusChangeHandlerProvider.StatusChange
             }
 
             if (openShiftService.isScaled(deployment)) {
-                return new StatusUpdate(Integration.Status.Activated, stepsPerformed);
-            }
-        } catch (@SuppressWarnings("PMD.AvoidCatchingGenericException") Exception e) {
-            LOG.error("{} : Failure", getLabel(integration), e);
-        }
-        return new StatusUpdate(Integration.Status.Pending, stepsPerformed);
+                //Once an IntegrationRevision is published and transfered to the state Active it becomes immutable and can not be changed afterwards (except for state related properties).
+                dataManager.update(new Integration.Builder().createFrom(integration)
+                    .draftRevision(Optional.empty())
+                    .addRevision(versionedRevision.withCurrentState(IntegrationState.Active))
+                    .deployedRevisionId(revision.getVersion())
+                    .build());
 
+                return new StatusUpdate(version, IntegrationState.Active, stepsPerformed);
+            }
+        } catch (@SuppressWarnings("PMD.AvoidCatchingGenericException")Exception e) {
+            LOG.info("{} : Failure", getLabel(integration), e);
+        }
+        return new StatusUpdate(version, IntegrationState.Pending, stepsPerformed);
     }
 
     protected String getCloneURL(Integration integration)  {
@@ -138,17 +164,6 @@ public class ActivateHandler implements StatusChangeHandlerProvider.StatusChange
         } catch (IOException e) {
             throw SyndesisServerException.launderThrowable(e);
         }
-    }
-
-    private boolean isTokenExpired(Integration integration) {
-        return integration.getToken().isPresent() &&
-               Tokens.isTokenExpired(integration.getToken().get());
-    }
-
-    private String storeToken(Integration integration) {
-        String token = integration.getToken().orElse(null);
-        Tokens.setAuthenticationToken(token);
-        return token;
     }
 
     private String getWebHookUrl(OpenShiftDeployment deployment, String secret) {
@@ -175,10 +190,12 @@ public class ActivateHandler implements StatusChangeHandlerProvider.StatusChange
         }
     }
 
-    private Map<String, byte[]> createProjectFiles(String username, Integration integration) {
+    private Map<String, byte[]> createProjectFiles(String username, Integration integration, IntegrationRevision revision) {
         try {
             GenerateProjectRequest request = new GenerateProjectRequest.Builder()
-                .integration(integration)
+                .id(integration.getId())
+                .name(integration.getName())
+                .spec(revision.getSpec())
                 .connectors(fetchConnectorsMap())
                 .gitHubRepoName(Names.sanitize(integration.getName()))
                 .gitHubUserLogin(username)
@@ -225,57 +242,67 @@ public class ActivateHandler implements StatusChangeHandlerProvider.StatusChange
      * The configuration should include:
      *  i) component properties
      *  ii) sensitive endpoint properties that should be masked.
-     * @param integration
+     * @param revision
      * @return
      */
-    private Properties extractApplicationPropertiesFrom(Integration integration) {
+    private Properties extractApplicationPropertiesFrom(IntegrationRevision revision) {
         Properties secrets = new Properties();
         Map<String, Connector> connectorMap = fetchConnectorsMap();
 
-        integration.getSteps().ifPresent(steps -> {
-            for (Step step : steps) {
-                if (step.getStepKind().equals(Endpoint.KIND)) {
-                    step.getAction().ifPresent(action -> {
-                        step.getConnection().ifPresent(connection -> {
-                            String connectorId = step.getConnection().get().getConnectorId().orElse(action.getConnectorId());
+        for (Step step : revision.getSpec().getSteps()) {
+            if (step.getStepKind().equals(Endpoint.KIND)) {
+                step.getAction().ifPresent(action -> {
+                    step.getConnection().ifPresent(connection -> {
+                        String connectorId = step.getConnection().get().getConnectorId().orElse(action.getConnectorId());
                             if (!connectorMap.containsKey(connectorId)) {
                                 throw new IllegalStateException("Connector:[" + connectorId + "] not found.");
                             }
-                            String prefix = action.getCamelConnectorPrefix();
-                            Connector connector = connectorMap.get(connectorId);
+                        String prefix = action.getCamelConnectorPrefix();
+                        Connector connector = connectorMap.get(connectorId);
 
-                            //Handle component data
-                            secrets.putAll(connector.filterProperties(connection.getConfiguredProperties(),
-                                connector.isComponentProperty(),
-                                e -> prefix + "." + e.getKey(),
-                                e -> e.getValue()));
+                        //Handle component data
+                        secrets.putAll(connector.filterProperties(connection.getConfiguredProperties(),
+                                                                  connector.isComponentProperty(),
+                                                                  e -> prefix + "." + e.getKey(),
+                                                                  e -> e.getValue()));
 
-                            secrets.putAll(connector.filterProperties(step.getConfiguredProperties().orElse(new HashMap<String,String>()),
-                                connector.isComponentProperty(),
-                                e -> prefix + "." + e.getKey(),
-                                e -> e.getValue()));
+                        secrets.putAll(connector.filterProperties(step.getConfiguredProperties().orElse(new HashMap<String,String>()),
+                                                                  connector.isComponentProperty(),
+                                                                  e -> prefix + "." + e.getKey(),
+                                                                  e -> e.getValue()));
 
-                            //Handle sensitive data
-                            secrets.putAll(connector.filterProperties(connection.getConfiguredProperties(),
-                                connector.isSecret(),
-                                e -> prefix + "." + e.getKey(),
-                                e -> e.getValue()));
+                        //Handle sensitive data
+                        secrets.putAll(connector.filterProperties(connection.getConfiguredProperties(),
+                                                                  connector.isSecret(),
+                                                                  e -> prefix + "." + e.getKey(),
+                                                                  e -> e.getValue()));
 
-                            secrets.putAll(connector.filterProperties(step.getConfiguredProperties().orElse(new HashMap<String,String>()),
-                                connector.isSecret(),
-                                e -> prefix + "." + e.getKey(),
-                                e -> e.getValue()));
-                        });
+                        secrets.putAll(connector.filterProperties(step.getConfiguredProperties().orElse(new HashMap<String,String>()),
+                                                                  connector.isSecret(),
+                                                                  e -> prefix + "." + e.getKey(),
+                                                                  e -> e.getValue()));
                     });
-                    continue;
-                }
+                });
+                continue;
             }
-        });
+        }
         return secrets;
     }
 
-    private String getLabel(Integration integration) {
+    private static String getLabel(Integration integration) {
         return "Integration " + integration.getId().orElse("[none]");
+    }
+
+
+    private static boolean isTokenExpired(Integration integration) {
+        return integration.getToken().isPresent() &&
+            Tokens.isTokenExpired(integration.getToken().get());
+    }
+
+    private static String storeToken(Integration integration) {
+        String token = integration.getToken().orElse(null);
+        Tokens.setAuthenticationToken(token);
+        return token;
     }
 
 }

--- a/controllers/src/main/java/io/syndesis/controllers/integration/online/OnlineHandlerProvider.java
+++ b/controllers/src/main/java/io/syndesis/controllers/integration/online/OnlineHandlerProvider.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2016 Red Hat, Inc.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,6 +18,7 @@ package io.syndesis.controllers.integration.online;
 import java.util.Arrays;
 import java.util.List;
 
+import io.syndesis.controllers.integration.StatusChangeHandler;
 import io.syndesis.controllers.integration.StatusChangeHandlerProvider;
 import io.syndesis.dao.manager.DataManager;
 import io.syndesis.github.GitHubService;
@@ -30,24 +31,28 @@ import org.springframework.stereotype.Component;
 @ConditionalOnProperty(value = "controllers.integration.enabled", havingValue = "true", matchIfMissing = true)
 public class OnlineHandlerProvider implements StatusChangeHandlerProvider {
 
-    private final DataManager dataManager;
-    private final OpenShiftService openShiftService;
-    private final GitHubService gitHubService;
-    private final ProjectGenerator projectConverter;
+    private final List<StatusChangeHandler> draftHandlers;
+
+    private final List<StatusChangeHandler> deployedHandlers;
 
     public OnlineHandlerProvider(DataManager dataManager, OpenShiftService openShiftService,
                                  GitHubService gitHubService, ProjectGenerator projectConverter) {
-        this.dataManager = dataManager;
-        this.openShiftService = openShiftService;
-        this.gitHubService = gitHubService;
-        this.projectConverter = projectConverter;
+
+        StatusChangeHandler activateHandler = new ActivateHandler(dataManager, openShiftService, gitHubService, projectConverter);
+        StatusChangeHandler deactivateHandler = new DeactivateHandler(openShiftService);
+        StatusChangeHandler deleteHandler = new DeleteHandler(openShiftService);
+
+        this.draftHandlers = Arrays.asList(activateHandler, deleteHandler);
+        this.deployedHandlers = Arrays.asList(deactivateHandler, deleteHandler);
     }
 
     @Override
-    public List<StatusChangeHandler> getStatusChangeHandlers() {
-        return Arrays.asList(
-            new ActivateHandler(dataManager, openShiftService, gitHubService, projectConverter),
-            new DeactivateHandler(openShiftService),
-            new DeleteHandler(openShiftService));
+    public List<StatusChangeHandler> getDraftStatusChangeHandlers() {
+        return draftHandlers;
+    }
+
+    @Override
+    public List<StatusChangeHandler> getDeployedStatusChangeHandlers() {
+        return deployedHandlers;
     }
 }

--- a/dao/src/main/resources/io/syndesis/dao/demo-data.json
+++ b/dao/src/main/resources/io/syndesis/dao/demo-data.json
@@ -25,7 +25,10 @@
       "description": "Salesforce Connection",
       "createdDate": 1492095344060,
       "lastUpdated": 1492095344060,
-      "tags":["example","test"],
+      "tags": [
+        "example",
+        "test"
+      ],
       "icon": "fa-globe",
       "connectorId": "salesforce",
       "configuredProperties": {
@@ -44,7 +47,10 @@
       "description": "HTTP Connection",
       "createdDate": 1492095344060,
       "lastUpdated": 1492095344060,
-      "tags":["example","test"],
+      "tags": [
+        "example",
+        "test"
+      ],
       "icon": "fa-globe",
       "connectorId": "http",
       "configuredProperties": {}
@@ -58,7 +64,10 @@
       "description": "Timer Connection",
       "createdDate": 1492095344060,
       "lastUpdated": 1492095344060,
-      "tags":["example","test"],
+      "tags": [
+        "example",
+        "test"
+      ],
       "icon": "fa-globe",
       "connectorId": "timer",
       "configuredProperties": {}
@@ -70,16 +79,24 @@
       "id": "1",
       "name": "Twitter to Salesforce Example",
       "description": "This is an example of a Twitter to Salesforce integration",
-      "configuration": "",
+      "tags": [
+        "example",
+        "test"
+      ],
       "createdDate": 1492095344060,
       "lastUpdated": 1492095344060,
-      "tags":["example","test"],
-      "currentStatus": "Activated",
-      "desiredStatus": "Activated",
-      "steps": [
-        {
-          "id": "1",
-          "stepKind": "endpoint",
+      "deployedRevisionId": 1,
+      "revisions": [
+      {
+      "status": {
+        "version": 1,
+          "state": "Active"
+          },
+          "spec": {
+            "state": "Active",
+            "steps": [
+              {
+                "stepKind": "endpoint",
           "connection": {
             "id": "1",
             "name": "Twitter Example",
@@ -100,7 +117,7 @@
             "name": "Twitter Mention",
             "camelConnectorGAV": "io.syndesis:twitter-mention-connector:@syndesis-connectors.version@",
             "camelConnectorPrefix": "twitter-mention",
-            "definition": {
+          "definition": {
               "inputDataShape": {
                   "kind" : "none"
               },
@@ -108,24 +125,23 @@
                   "kind" : "java",
                   "type" : "twitter4j.Status"
               }
-            }
-          },
+            }},
           "configuredProperties": {
           }
-        },{
-          "id": "2",
+        },
+          {
           "stepKind": "filter",
           "configuredProperties": {
             "filter": "${body.text} contains \"#RHSummit\""
             }
-        },{
-          "id": "3",
+        },
+          {
           "stepKind": "mapper",
           "configuredProperties": {
             "atlasmapping": "{ \"AtlasMapping\": { \"jsonType\": \"com.mediadriver.atlas.v2.AtlasMapping\", \"properties\": { \"property\": [] }, \"fieldMappings\": { \"fieldMapping\": [ { \"jsonType\": \"com.mediadriver.atlas.v2.SeparateFieldMapping\", \"inputField\": { \"jsonType\": \"com.mediadriver.atlas.v2.MappedField\", \"field\": { \"jsonType\": \"com.mediadriver.atlas.java.v2.JavaField\", \"name\": \"Name\", \"path\": \"User.name\", \"type\": \"STRING\", \"getMethod\": \"getName\" }, \"fieldActions\": { \"fieldAction\": [] } }, \"outputFields\": { \"mappedField\": [ { \"jsonType\": \"com.mediadriver.atlas.v2.MappedField\", \"field\": { \"jsonType\": \"com.mediadriver.atlas.java.v2.JavaField\", \"name\": \"FirstName\", \"path\": \"FirstName\", \"type\": \"STRING\", \"setMethod\": \"setFirstName\" }, \"fieldActions\": { \"fieldAction\": [ { \"jsonType\": \"com.mediadriver.atlas.v2.MapAction\", \"index\": 0 } ] } }, { \"jsonType\": \"com.mediadriver.atlas.v2.MappedField\", \"field\": { \"jsonType\": \"com.mediadriver.atlas.java.v2.JavaField\", \"name\": \"LastName\", \"path\": \"LastName\", \"type\": \"STRING\", \"setMethod\": \"setLastName\" }, \"fieldActions\": { \"fieldAction\": [ { \"jsonType\": \"com.mediadriver.atlas.v2.MapAction\", \"index\": 1 } ] } } ] } }, { \"jsonType\": \"com.mediadriver.atlas.v2.MapFieldMapping\", \"inputField\": { \"jsonType\": \"com.mediadriver.atlas.v2.MappedField\", \"field\": { \"jsonType\": \"com.mediadriver.atlas.java.v2.JavaField\", \"name\": \"Text\", \"path\": \"Text\", \"type\": \"STRING\", \"getMethod\": \"getText\" }, \"fieldActions\": { \"fieldAction\": [] } }, \"outputField\": { \"jsonType\": \"com.mediadriver.atlas.v2.MappedField\", \"field\": { \"jsonType\": \"com.mediadriver.atlas.java.v2.JavaField\", \"name\": \"Description\", \"path\": \"description\", \"type\": \"STRING\", \"setMethod\": \"setDescription\" }, \"fieldActions\": { \"fieldAction\": [] } } }, { \"jsonType\": \"com.mediadriver.atlas.v2.MapFieldMapping\", \"inputField\": { \"jsonType\": \"com.mediadriver.atlas.v2.MappedField\", \"field\": { \"jsonType\": \"com.mediadriver.atlas.java.v2.JavaField\", \"name\": \"ScreenName\", \"path\": \"User.screenName\", \"type\": \"STRING\", \"getMethod\": \"getScreenName\" }, \"fieldActions\": { \"fieldAction\": [] } }, \"outputField\": { \"jsonType\": \"com.mediadriver.atlas.v2.MappedField\", \"field\": { \"jsonType\": \"com.mediadriver.atlas.java.v2.JavaField\", \"name\": \"Title\", \"path\": \"Title\", \"type\": \"STRING\", \"setMethod\": \"setTitle\" }, \"fieldActions\": { \"fieldAction\": [] } } } ] }, \"name\": \"twitterStatusToSalesforceContact\", \"sourceUri\": \"atlas:java?className=twitter4j.Status\", \"targetUri\": \"atlas:java?className=io.syndesis.connector.salesforce.Contact\" } } "
            }
-        },{
-          "id": "4",
+        },
+          {
           "stepKind": "endpoint",
           "connection": {
             "id": "2",
@@ -157,7 +173,9 @@
               }
             }
           },
-          "configuredProperties": {
+          "configuredProperties": {}
+              }
+            ]
           }
         }
       ]
@@ -169,16 +187,21 @@
       "id": "2",
       "name": "Timed Pull to Post Example",
       "description": "This is an example of a Timed Pull to Post Integration",
-      "configuration": "",
-      "createdDate": 1492095344060,
-      "lastUpdated": 1492095344060,
-      "desiredStatus": "Activated",
-      "currentStatus": "Activated",
-      "statusMessage": "This integration failed. Please contact system admin for errors.",
-      "tags":["example","test"],
+      "tags": [
+      "example",
+      "test"
+      ],
+      "deployedRevisionId": 1,
+      "revisions": [
+        {
+          "status": {
+            "version": 1,
+            "state": "Active",
+            "message": "This integration failed. Please contact system admin for errors."
+      },
+          "spec": {
       "steps": [
         {
-          "id": "5",
           "stepKind": "endpoint",
           "connection": {
             "id": "4",
@@ -194,20 +217,19 @@
             "description": "Set a timer that fires at intervals that you specify",
             "camelConnectorGAV": "io.syndesis:timer-connector:@syndesis-connectors.version@",
             "camelConnectorPrefix": "periodic-timer",
-            "definition": {
+          "definition": {
               "inputDataShape": {
                  "kind" : "none"
               },
               "outputDataShape": {
                  "kind" : "any"
               }
-            }
-          },
+            }},
           "configuredProperties": {
             "period": "500"
           }
-        },{
-          "id": "6",
+        },
+          {
           "stepKind": "log",
           "configuredProperties": {
             "message": "Hello World! ${body}",
@@ -215,7 +237,6 @@
           }
         },
         {
-          "id": "7",
           "stepKind": "endpoint",
           "connection": {
             "id": "3",
@@ -231,20 +252,19 @@
             "description": "Call a service that is internal (within your company) or external (on the internet) by specifying the service's URL",
             "camelConnectorGAV": "io.syndesis:http-post-connector:@syndesis-connectors.version@",
             "camelConnectorPrefix": "http-post",
-            "definition": {
+          "definition": {
               "inputDataShape": {
                  "kind" : "any"
               },
               "outputDataShape": {
                  "kind" : "any"
               }
-            }
-          },
+            }},
           "configuredProperties": {
             "httpUri": "http://localhost:8080/bye"
           }
-        },{
-          "id": "8",
+        },
+          {
           "stepKind": "endpoint",
           "connection": {
             "id": "3",
@@ -270,7 +290,9 @@
             }
           },
           "configuredProperties": {
-            "httpUri": "http://localhost:8080/hello"
+            "httpUri": "http://localhost:8080/hello"}
+              }
+            ]
           }
         }
       ]
@@ -282,15 +304,23 @@
       "id": "3",
       "name": "Breakaway Example",
       "description": "This is an example in Active state",
-      "configuration": "",
+      "tags": [
+        "example",
+        "test"
+      ],
       "createdDate": 1492095344060,
       "lastUpdated": 1492095344060,
-      "desiredStatus": "Activated",
-      "currentStatus": "Activated",
-      "tags":["example","test"],
-      "steps": [
-        {
-          "id": "5",
+      "deployedRevisionId": 1,
+      "revisions": [
+      {
+      "status": {
+        "version": 1,
+          "state": "Active"
+          },
+          "spec": {
+            "state": "Active",
+            "steps": [
+              {
           "stepKind": "endpoint",
           "connection": {
             "id": "4",
@@ -306,20 +336,19 @@
             "description": "Set a timer that fires at intervals that you specify",
             "camelConnectorGAV": "io.syndesis:timer-connector:@syndesis-connectors.version@",
             "camelConnectorPrefix": "periodic-timer",
-            "definition": {
+          "definition": {
               "inputDataShape": {
                  "kind" : "none"
               },
               "outputDataShape": {
                  "kind" : "any"
               }
-            }
-          },
+            }},
           "configuredProperties": {
             "period": "500"
           }
-        },{
-          "id": "6",
+        },
+          {
           "stepKind": "log",
           "configuredProperties": {
             "message": "Hello World! ${body}",
@@ -327,7 +356,6 @@
           }
         },
         {
-          "id": "7",
           "stepKind": "endpoint",
           "connection": {
             "id": "3",
@@ -343,20 +371,19 @@
             "description": "Call a service that is internal (within your company) or external (on the internet) by specifying the service's URL",
             "camelConnectorGAV": "io.syndesis:http-post-connector:@syndesis-connectors.version@",
             "camelConnectorPrefix": "http-post",
-            "definition": {
+          "definition": {
               "inputDataShape": {
                  "kind" : "any"
               },
               "outputDataShape": {
                  "kind" : "any"
               }
-            }
-          },
+            }},
           "configuredProperties": {
             "httpUri": "http://localhost:8080/bye"
           }
-        },{
-          "id": "8",
+        },
+          {
           "stepKind": "endpoint",
           "connection": {
             "id": "3",
@@ -382,7 +409,9 @@
             }
           },
           "configuredProperties": {
-            "httpUri": "http://localhost:8080/hello"
+            "httpUri": "http://localhost:8080/hello"}
+              }
+            ]
           }
         }
       ]
@@ -393,16 +422,24 @@
     "data": {
       "id": "4",
       "name": "Facebook Message to Twitter",
-      "description": "This is an example in Deactivated state",
-      "configuration": "",
+      "description": "This is an example in Inactive state",
+      "tags": [
+        "example",
+        "test"
+      ],
       "createdDate": 1492095344060,
       "lastUpdated": 1492095344060,
-      "desiredStatus": "Deactivated",
-      "currentStatus": "Deactivated",
-      "tags":["example","test"],
-      "steps": [
-        {
-          "id": "5",
+      "deployedRevisionId": 1,
+      "revisions": [
+      {
+      "status": {
+        "version": 1,
+          "state": "Inactive"
+          },
+          "spec": {
+            "state": "Inactive",
+            "steps": [
+              {
           "stepKind": "endpoint",
           "connection": {
             "id": "4",
@@ -418,20 +455,19 @@
             "description": "Set a timer that fires at intervals that you specify",
             "camelConnectorGAV": "io.syndesis:timer-connector:@syndesis-connectors.version@",
             "camelConnectorPrefix": "periodic-timer",
-            "definition": {
+          "definition": {
               "inputDataShape": {
                  "kind" : "none"
               },
               "outputDataShape": {
                  "kind" : "any"
               }
-            }
-          },
+            }},
           "configuredProperties": {
             "period": "500"
           }
-        },{
-          "id": "6",
+        },
+          {
           "stepKind": "log",
           "configuredProperties": {
             "message": "Hello World! ${body}",
@@ -439,7 +475,6 @@
           }
         },
         {
-          "id": "7",
           "stepKind": "endpoint",
           "connection": {
             "id": "3",
@@ -455,20 +490,19 @@
             "description": "Call a service that is internal (within your company) or external (on the internet) by specifying the service's URL",
             "camelConnectorGAV": "io.syndesis:http-post-connector:@syndesis-connectors.version@",
             "camelConnectorPrefix": "http-post",
-            "definition": {
+          "definition": {
               "inputDataShape": {
                  "kind" : "any"
               },
               "outputDataShape": {
                  "kind" : "any"
               }
-            }
-          },
+            }},
           "configuredProperties": {
             "httpUri": "http://localhost:8080/bye"
           }
-        },{
-          "id": "8",
+        },
+          {
           "stepKind": "endpoint",
           "connection": {
             "id": "3",
@@ -494,7 +528,9 @@
             }
           },
           "configuredProperties": {
-            "httpUri": "http://localhost:8080/hello"
+            "httpUri": "http://localhost:8080/hello"}
+              }
+            ]
           }
         }
       ]
@@ -506,15 +542,20 @@
       "id": "5",
       "name": "Facebook Photo to Twitter",
       "description": "This is an example in Pending state",
-      "configuration": "",
+      "tags": [
+        "example",
+        "test"
+      ],
       "createdDate": 1492095344060,
       "lastUpdated": 1492095344060,
-      "desiredStatus": "Activated",
-      "currentStatus": "Pending",
-      "tags":["example","test"],
-      "steps": [
-        {
-          "id": "5",
+      "draftRevision": {
+      "status": {
+      "state": "Inactive"
+      },
+        "spec":{
+          "state": "Active",
+          "steps": [
+            {
           "stepKind": "endpoint",
           "connection": {
             "id": "4",
@@ -530,20 +571,19 @@
             "description": "Set a timer that fires at intervals that you specify",
             "camelConnectorGAV": "io.syndesis:timer-connector:@syndesis-connectors.version@",
             "camelConnectorPrefix": "periodic-timer",
-            "definition": {
+          "definition": {
               "inputDataShape": {
                  "kind" : "none"
               },
               "outputDataShape": {
                  "kind" : "any"
               }
-            }
-          },
+            }},
           "configuredProperties": {
             "period": "500"
           }
-        },{
-          "id": "6",
+        },
+          {
           "stepKind": "log",
           "configuredProperties": {
             "message": "Hello World! ${body}",
@@ -551,7 +591,6 @@
           }
         },
         {
-          "id": "7",
           "stepKind": "endpoint",
           "connection": {
             "id": "3",
@@ -567,20 +606,19 @@
             "description": "Call a service that is internal (within your company) or external (on the internet) by specifying the service's URL",
             "camelConnectorGAV": "io.syndesis:http-post-connector:@syndesis-connectors.version@",
             "camelConnectorPrefix": "http-post",
-            "definition": {
+          "definition": {
               "inputDataShape": {
                  "kind" : "any"
               },
               "outputDataShape": {
                  "kind" : "any"
               }
-            }
-          },
+            }},
           "configuredProperties": {
             "httpUri": "http://localhost:8080/bye"
           }
-        },{
-          "id": "8",
+        },
+          {
           "stepKind": "endpoint",
           "connection": {
             "id": "3",
@@ -609,7 +647,8 @@
             "httpUri": "http://localhost:8080/hello"
           }
         }
-      ]
+      ]}
+      }
     }
   },
   {
@@ -618,15 +657,23 @@
       "id": "6",
       "name": "Update Client Service Example",
       "description": "This is an example in Draft state",
-      "configuration": "",
+      "tags": [
+        "example",
+        "test"
+      ],
       "createdDate": 1492095344060,
       "lastUpdated": 1492095344060,
-      "desiredStatus": "Draft",
-      "currentStatus": "Draft",
-      "tags":["example","test"],
-      "steps": [
+      "deployedRevisionId": 1,
+      "revisions": [
         {
-          "id": "5",
+          "status": {
+            "version": 1,
+            "state": "Draft"
+      },
+      "spec": {
+        "state": "Draft",
+          "steps": [
+              {
           "stepKind": "endpoint",
           "connection": {
             "id": "4",
@@ -642,20 +689,19 @@
             "description": "Set a timer that fires at intervals that you specify",
             "camelConnectorGAV": "io.syndesis:timer-connector:@syndesis-connectors.version@",
             "camelConnectorPrefix": "periodic-timer",
-            "definition": {
+          "definition": {
               "inputDataShape": {
                  "kind" : "none"
               },
               "outputDataShape": {
                  "kind" : "any"
               }
-            }
-          },
+            }},
           "configuredProperties": {
             "period": "500"
           }
-        },{
-          "id": "6",
+        },
+          {
           "stepKind": "log",
           "configuredProperties": {
             "message": "Hello World! ${body}",
@@ -663,7 +709,6 @@
           }
         },
         {
-          "id": "7",
           "stepKind": "endpoint",
           "connection": {
             "id": "3",
@@ -679,20 +724,19 @@
             "description": "Call a service that is internal (within your company) or external (on the internet) by specifying the service's URL",
             "camelConnectorGAV": "io.syndesis:http-post-connector:@syndesis-connectors.version@",
             "camelConnectorPrefix": "http-post",
-            "definition": {
+          "definition": {
               "inputDataShape": {
                  "kind" : "any"
               },
               "outputDataShape": {
                  "kind" : "any"
               }
-            }
-          },
+            }},
           "configuredProperties": {
             "httpUri": "http://localhost:8080/bye"
           }
-        },{
-          "id": "8",
+        },
+          {
           "stepKind": "endpoint",
           "connection": {
             "id": "3",
@@ -718,7 +762,9 @@
             }
           },
           "configuredProperties": {
-            "httpUri": "http://localhost:8080/hello"
+            "httpUri": "http://localhost:8080/hello"}
+              }
+            ]
           }
         }
       ]
@@ -728,17 +774,25 @@
     "kind": "integration",
     "data": {
       "id": "7",
-      "name": "Deleted Client Service Example",
-      "description": "This is an example in Deleted state",
-      "configuration": "",
+      "name": "Undeployed Client Service Example",
+      "description": "This is an example in Undeployed state",
+      "tags": [
+        "example",
+        "test"
+      ],
       "createdDate": 1492095344060,
       "lastUpdated": 1492095344060,
-      "desiredStatus": "Deleted",
-      "currentStatus": "Deleted",
-      "tags":["example","test"],
-      "steps": [
-        {
-          "id": "5",
+      "deployedRevisionId": 1,
+      "revisions": [
+      {
+      "status": {
+        "version": 1,
+          "state": "Undeployed"
+          },
+          "spec": {
+            "state": "Undeployed",
+            "steps": [
+              {
           "stepKind": "endpoint",
           "connection": {
             "id": "4",
@@ -754,20 +808,19 @@
             "description": "Set a timer that fires at intervals that you specify",
             "camelConnectorGAV": "io.syndesis:timer-connector:@syndesis-connectors.version@",
             "camelConnectorPrefix": "periodic-timer",
-            "definition": {
+          "definition": {
               "inputDataShape": {
                  "kind" : "none"
               },
               "outputDataShape": {
                  "kind" : "any"
               }
-            }
-          },
+            }},
           "configuredProperties": {
             "period": "500"
           }
-        },{
-          "id": "6",
+        },
+          {
           "stepKind": "log",
           "configuredProperties": {
             "message": "Hello World! ${body}",
@@ -775,7 +828,6 @@
           }
         },
         {
-          "id": "7",
           "stepKind": "endpoint",
           "connection": {
             "id": "3",
@@ -791,20 +843,19 @@
             "description": "Call a service that is internal (within your company) or external (on the internet) by specifying the service's URL",
             "camelConnectorGAV": "io.syndesis:http-post-connector:@syndesis-connectors.version@",
             "camelConnectorPrefix": "http-post",
-            "definition": {
+          "definition": {
               "inputDataShape": {
                  "kind" : "any"
               },
               "outputDataShape": {
                  "kind" : "any"
               }
-            }
-          },
+            }},
           "configuredProperties": {
             "httpUri": "http://localhost:8080/bye"
           }
-        },{
-          "id": "8",
+        },
+          {
           "stepKind": "endpoint",
           "connection": {
             "id": "3",
@@ -830,7 +881,9 @@
             }
           },
           "configuredProperties": {
-            "httpUri": "http://localhost:8080/hello"
+            "httpUri": "http://localhost:8080/hello"}
+              }
+            ]
           }
         }
       ]

--- a/dao/src/test/java/io/syndesis/dao/DataManagerTest.java
+++ b/dao/src/test/java/io/syndesis/dao/DataManagerTest.java
@@ -17,6 +17,7 @@ package io.syndesis.dao;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 
@@ -29,6 +30,9 @@ import io.syndesis.model.connection.Connection;
 import io.syndesis.model.connection.Connector;
 import io.syndesis.model.integration.Integration;
 
+import io.syndesis.model.integration.IntegrationRevision;
+import io.syndesis.model.integration.IntegrationRevisionSpec;
+import io.syndesis.model.integration.IntegrationState;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -104,14 +108,21 @@ public class DataManagerTest {
     public void getIntegration() throws IOException {
         Integration integration = dataManager.fetch(Integration.class, "1");
         Assert.assertEquals("Example Integration", "Twitter to Salesforce Example", integration.getName());
-        Assert.assertEquals(4, integration.getSteps().get().size());
+        Assert.assertEquals(4, integration.getDeployedRevision().get().getSpec().getSteps().size());
         Assert.assertTrue(integration.getTags().contains("example"));
 
         //making sure we can deserialize Enums such as StatusType
-        Integration int2 = new Integration.Builder().createFrom(integration).desiredStatus(Integration.Status.Activated).build();
+        Integration int2 = new Integration.Builder()
+            .createFrom(integration)
+            .revisions(Arrays.<IntegrationRevision>asList(new IntegrationRevision.Builder()
+                .createFrom(integration.getDeployedRevision().get())
+                .spec(new IntegrationRevisionSpec.Builder().state(IntegrationState.Active).build())
+                .build()))
+            .build();
+
         String json = Json.mapper().writeValueAsString(int2);
         Integration int3 = Json.mapper().readValue(json, Integration.class);
-        Assert.assertEquals(int2.getDesiredStatus(), int3.getDesiredStatus());
+        Assert.assertEquals(int2.getDeployedRevision().map(r -> r.getDesiredState()), int3.getDeployedRevision().map(r -> r.getDesiredState()));
     }
 
     @Test

--- a/dao/src/test/java/io/syndesis/dao/ReadApiClientDataTest.java
+++ b/dao/src/test/java/io/syndesis/dao/ReadApiClientDataTest.java
@@ -31,6 +31,10 @@ import io.syndesis.model.connection.Connector;
 import io.syndesis.model.connection.ConnectorGroup;
 import io.syndesis.model.integration.Integration;
 
+import io.syndesis.model.integration.IntegrationRevision;
+import io.syndesis.model.integration.IntegrationRevisionSpec;
+import io.syndesis.model.integration.IntegrationRevisionStatus;
+import io.syndesis.model.integration.IntegrationState;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -43,14 +47,18 @@ public class ReadApiClientDataTest {
     public void deserializeModelDataTest() throws IOException {
 
         Integration integrationIn = new Integration.Builder()
-                    .desiredStatus(Integration.Status.Activated)
+                    .draftRevision(new IntegrationRevision.Builder()
+                        .status(new IntegrationRevisionStatus.Builder().version(1).build())
+                        .spec(new IntegrationRevisionSpec.Builder().state(IntegrationState.Active).build())
+                        .build())
                     .tags(new TreeSet<>(Arrays.asList("tag1", "tag2")))
                     .createdDate(new Date())
                     .build();
+
         String integrationJson = mapper.writeValueAsString(integrationIn);
         System.out.println(integrationJson);
         Integration integrationOut = mapper.readValue(integrationJson, Integration.class);
-        Assert.assertEquals(integrationIn.getDesiredStatus(), integrationOut.getDesiredStatus());
+        Assert.assertEquals(integrationIn.getDraftRevision().get().getDesiredState(), integrationOut.getDraftRevision().get().getDesiredState());
 
         //serialize
         ConnectorGroup cg = new ConnectorGroup.Builder().id("label").name("label").build();

--- a/model/src/main/java/io/syndesis/model/Kind.java
+++ b/model/src/main/java/io/syndesis/model/Kind.java
@@ -34,6 +34,7 @@ public enum Kind {
     Organization(io.syndesis.model.environment.Organization.class),
 
     Integration(io.syndesis.model.integration.Integration.class),
+    IntegrationRevision(io.syndesis.model.integration.IntegrationRevision.class),
     IntegrationRuntime(io.syndesis.model.integration.IntegrationRuntime.class),
     Step(io.syndesis.model.integration.Step.class),
 
@@ -43,7 +44,7 @@ public enum Kind {
     ;
 
     public final String modelName;
-    public final Class<? extends WithId<?>> modelClass;
+    public final Class<? extends WithKind> modelClass;
 
     private static final Map<String, Kind> NAME_MAP;
     private static final Map<Class<?>, Kind> MODEL_MAP;
@@ -60,11 +61,11 @@ public enum Kind {
         MODEL_MAP = Collections.unmodifiableMap(kindByType);
     }
 
-    Kind(Class<? extends WithId<?>> model) {
+    Kind(Class<? extends WithKind> model) {
         this(name(model.getSimpleName()), model);
     }
 
-    Kind(String name, Class<? extends WithId<?>> model) {
+    Kind(String name, Class<? extends WithKind> model) {
         this.modelName = name;
         this.modelClass = model;
     }

--- a/model/src/main/java/io/syndesis/model/WithKind.java
+++ b/model/src/main/java/io/syndesis/model/WithKind.java
@@ -17,7 +17,7 @@ package io.syndesis.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-public interface WithKind {
+public interface WithKind<T> {
     @JsonIgnore
     Kind getKind();
 }

--- a/model/src/main/java/io/syndesis/model/integration/Integration.java
+++ b/model/src/main/java/io/syndesis/model/integration/Integration.java
@@ -15,61 +15,63 @@
  */
 package io.syndesis.model.integration;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import io.syndesis.model.Kind;
-import io.syndesis.model.WithId;
-import io.syndesis.model.WithName;
-import io.syndesis.model.WithTags;
-import io.syndesis.model.connection.Connection;
-import io.syndesis.model.user.User;
-import io.syndesis.model.validation.UniqueProperty;
-import io.syndesis.model.validation.UniquenessRequired;
-
-import org.immutables.value.Value;
-
 import java.io.Serializable;
 import java.math.BigInteger;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.syndesis.model.Kind;
+import io.syndesis.model.WithId;
+import io.syndesis.model.WithName;
+import io.syndesis.model.WithTags;
+import io.syndesis.model.validation.UniqueProperty;
+import io.syndesis.model.validation.UniquenessRequired;
+import org.immutables.value.Value;
+
 @Value.Immutable
 @JsonDeserialize(builder = Integration.Builder.class)
 @UniqueProperty(value = "name", groups = UniquenessRequired.class)
 public interface Integration extends WithId<Integration>, WithTags, WithName, Serializable {
-
-    enum Status { Draft, Pending, Activated, Deactivated, Deleted}
 
     @Override
     default Kind getKind() {
         return Kind.Integration;
     }
 
-    Optional<String> getConfiguration();
+    Optional<String> getDescription();
 
-    Optional<String> getIntegrationTemplateId();
+    /**
+     * The list of versioned revisions.
+     * The items in this list should be versioned and are not meant to be mutated.
+     * @return
+     */
+    List<IntegrationRevision> getRevisions();
+
+    Optional<IntegrationRevision> getDraftRevision();
+
+    Optional<Integer> getDeployedRevisionId();
+
+    @JsonIgnore
+    default Optional<IntegrationRevision> getDeployedRevision() {
+        return getDeployedRevisionId().map(i -> getRevisions()
+            .stream()
+            .filter(r -> r.getVersion().isPresent() && i.equals(r.getVersion().get()))
+            .findFirst()
+            .orElse(null));
+    }
+
+    IntegrationRevisionSpec getSpec();
 
     Optional<String> getUserId();
 
     Optional<String> getToken();
 
-    List<User> getUsers();
-
-    Optional<List<Connection>> getConnections();
-
-    Optional<List<? extends Step>> getSteps();
-
-    Optional<String> getDescription();
-
     Optional<String> getGitRepo();
 
-    Optional<Status> getDesiredStatus();
-
-    Optional<Status> getCurrentStatus();
-
     Optional<List<String>> getStepsDone();
-
-    Optional<String> getStatusMessage();
 
     Optional<Date> getLastUpdated();
 

--- a/model/src/main/java/io/syndesis/model/integration/IntegrationRevision.java
+++ b/model/src/main/java/io/syndesis/model/integration/IntegrationRevision.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.model.integration;
+
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.syndesis.model.Kind;
+import io.syndesis.model.WithKind;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonDeserialize(builder = IntegrationRevision.Builder.class)
+public interface IntegrationRevision extends WithKind {
+
+    @Override
+    default Kind getKind() {
+        return Kind.IntegrationRevision;
+    }
+
+    /**
+     * Specification of this revision
+     */
+    IntegrationRevisionSpec getSpec();
+
+    /**
+     * The actual status of the integration revision
+     */
+    Optional<IntegrationRevisionStatus> getStatus();
+
+
+    // ===================================================================
+    // Builder methods
+
+    default IntegrationRevision withVersion(Integer version) {
+        IntegrationRevisionStatus.Builder builder = new IntegrationRevisionStatus.Builder();
+        IntegrationRevisionStatus status =
+            getStatus().map(builder::createFrom).orElse(builder).version(version).build();
+        return new IntegrationRevision.Builder().createFrom(this).status(status).build();
+    }
+
+    default IntegrationRevision withCurrentState(IntegrationState state) {
+        IntegrationRevisionStatus.Builder builder = new IntegrationRevisionStatus.Builder();
+        IntegrationRevisionStatus status =
+            getStatus().map(builder::createFrom).orElse(builder).state(state).build();
+        return new IntegrationRevision.Builder().createFrom(this).status(status).build();
+    }
+
+    default IntegrationRevision withCurrentState(IntegrationState state, String message) {
+        IntegrationRevisionStatus.Builder builder = new IntegrationRevisionStatus.Builder();
+        IntegrationRevisionStatus status =
+            getStatus().map(builder::createFrom).orElse(builder)
+                       .state(state)
+                       .message(message)
+                       .build();
+        return new IntegrationRevision.Builder().createFrom(this).status(status).build();
+    }
+
+    class Builder extends ImmutableIntegrationRevision.Builder { }
+
+    // ===================================================================
+    // Convenient access functions
+
+    /**
+     * The revision number. This is unique per {@link Integration}.
+     * Once an {@link IntegrationRevision} gets a version, it should not be mutated anymore.
+     */
+    @JsonIgnore
+    default Optional<Integer> getVersion() {
+        return getStatus().flatMap(IntegrationRevisionStatus::getVersion);
+    }
+
+    /**
+     * The desired state of the revision.
+     */
+    @JsonIgnore
+    default IntegrationState getDesiredState() {
+        return getSpec().getState();
+    }
+
+    /**
+     * The current state of the revision.
+     */
+    @JsonIgnore
+    default IntegrationState getCurrentState() {
+        return getStatus().map(IntegrationRevisionStatus::getState).orElse(IntegrationState.Draft);
+    }
+
+    /**
+     * Returns that {@link IntegrationState}.
+     * The state is either the `desired state` or `pending`.
+     * @return true, if current state is matching with target, false otherwise.
+     */
+    @JsonIgnore
+    default boolean isPending() {
+        return getDesiredState() != getCurrentState();
+    }
+}

--- a/model/src/main/java/io/syndesis/model/integration/IntegrationRevisionSpec.java
+++ b/model/src/main/java/io/syndesis/model/integration/IntegrationRevisionSpec.java
@@ -13,36 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.syndesis.model.integration;
 
-import java.util.Map;
-import java.util.Optional;
+import java.util.List;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import io.syndesis.model.Kind;
-import io.syndesis.model.connection.Action;
-import io.syndesis.model.connection.Connection;
 import org.immutables.value.Value;
 
+/**
+ * An integration revision is a specific version of a certain integration. It belongs to
+ * exactly one integration and has a certain state {@link IntegrationState}
+ */
 @Value.Immutable
-@JsonDeserialize(builder = SimpleStep.Builder.class)
-public interface SimpleStep extends Step {
+@JsonDeserialize(builder = IntegrationRevisionSpec.Builder.class)
+public interface IntegrationRevisionSpec {
 
-    @Override
-    @Value.Default default Kind getKind() {
-        return Kind.Step;
-    }
+    /**
+     * Desired state of this revision
+     */
+    IntegrationState getState();
 
-    Optional<Action> getAction();
+    /**
+     * List of steps which build up this revision. Mandatory field.
+     */
+    List<Step> getSteps();
 
-    Optional<Connection> getConnection();
+    // ============================================================
 
-    String getStepKind();
-
-    Optional<Map<String, String>> getConfiguredProperties();
-
-    String getName();
-
-    class Builder extends ImmutableSimpleStep.Builder { }
+    class Builder extends ImmutableIntegrationRevisionSpec.Builder { }
 
 }

--- a/model/src/main/java/io/syndesis/model/integration/IntegrationRevisionStatus.java
+++ b/model/src/main/java/io/syndesis/model/integration/IntegrationRevisionStatus.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.model.integration;
+
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+/**
+ * Class which encapsulate the current status of the IntegrationRevision.
+ *
+ * The status is a collection of information, including the <em>state</em> of the integration.
+ *
+ * @author roland
+ * @since 31.08.17
+ */
+
+@Value.Immutable
+@JsonDeserialize(builder = IntegrationRevisionStatus.Builder.class)
+public interface IntegrationRevisionStatus {
+
+
+    /**
+     * The current state of the revision.
+     */
+    IntegrationState getState();
+
+    /**
+     * Message describing the currentState further (e.g. error message)
+     */
+    Optional<String> getMessage();
+
+    /**
+     * The revision number. This is unique per {@link Integration}.
+     * Once an {@link IntegrationRevision} gets a version, it should not be mutated anymore.
+     */
+    Optional<Integer> getVersion();
+
+    /**
+     * The version of the integration revision which was the origin of this revision.
+     * @return 0 if this is the first revision of an integration, the parent version otherwise.
+     */
+    Integer getParentVersion();
+
+    class Builder extends ImmutableIntegrationRevisionStatus.Builder { }
+}

--- a/model/src/main/java/io/syndesis/model/integration/IntegrationState.java
+++ b/model/src/main/java/io/syndesis/model/integration/IntegrationState.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.model.integration;
+
+public enum IntegrationState {
+    /**
+     * Initial state of an {@link IntegrationRevision}. The IntegrationRevision is not yet deployed.
+     */
+    Draft,
+
+    /**
+     * {@link IntegrationRevision} is deployed and running.
+     */
+    Active,
+    /**
+     * {@link IntegrationRevision} is deployed but is not running.
+     */
+    Inactive,
+    /**
+     * IntegrationRevision has been un-deployed.
+     */
+    Undeployed,
+
+    /**
+     * The {@link IntegrationRevision} is deployed but in an error state.
+     */
+    Error,
+
+    /**
+     * The {@link IntegrationRevision} is in peding state. (Desired != Actual).
+     */
+    Pending,
+}

--- a/model/src/main/java/io/syndesis/model/integration/Step.java
+++ b/model/src/main/java/io/syndesis/model/integration/Step.java
@@ -15,18 +15,18 @@
  */
 package io.syndesis.model.integration;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import io.syndesis.model.Kind;
-import io.syndesis.model.WithId;
-import io.syndesis.model.connection.Action;
-import io.syndesis.model.connection.Connection;
-
 import java.io.Serializable;
 import java.util.Map;
 import java.util.Optional;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.syndesis.model.Kind;
+import io.syndesis.model.WithKind;
+import io.syndesis.model.connection.Action;
+import io.syndesis.model.connection.Connection;
+
 @JsonDeserialize(using = StepDeserializer.class)
-public interface Step extends WithId<Step>, Serializable {
+public interface Step extends WithKind, Serializable {
 
     @Override
     default Kind getKind() {

--- a/model/src/test/java/io/syndesis/model/integration/StepDeserializerTest.java
+++ b/model/src/test/java/io/syndesis/model/integration/StepDeserializerTest.java
@@ -31,7 +31,6 @@ public class StepDeserializerTest {
     @Test
     public void shouldDeserializeRuleFilterStep() throws Exception {
         RuleFilterStep step = readTestFilter("/rule-filter-step.json");
-        assertEquals("1", step.getId().get());
         assertTrue(step.getConfiguredProperties().isPresent());
         Map<String, String> props = step.getConfiguredProperties().get();
         assertEquals(FilterPredicate.AND, FilterPredicate.valueOf(props.get("predicate").toUpperCase(Locale.US)));
@@ -45,7 +44,6 @@ public class StepDeserializerTest {
         ExpressionFilterStep step = readTestFilter("/filter-step.json");
         ExpressionFilterStep exprFilterStep = (ExpressionFilterStep) step;
         String expr = "${body.text} contains '#RHSummit'";
-        assertEquals("2", exprFilterStep.getId().get());
         assertEquals("filter", exprFilterStep.getStepKind());
         assertEquals(expr, exprFilterStep.getFilterExpression());
         assertEquals(1, exprFilterStep.getConfiguredProperties().get().size());

--- a/model/src/test/resources/filter-step.json
+++ b/model/src/test/resources/filter-step.json
@@ -1,5 +1,4 @@
 {
-  "id": "2",
   "kind": "Step",
   "stepKind": "filter",
   "configuredProperties": {

--- a/model/src/test/resources/rule-filter-step.json
+++ b/model/src/test/resources/rule-filter-step.json
@@ -1,5 +1,4 @@
 {
-  "id": "1",
   "kind": "Step",
   "stepKind": "rule-filter",
   "configuredProperties": {

--- a/openshift/src/main/java/io/syndesis/openshift/OpenShiftDeployment.java
+++ b/openshift/src/main/java/io/syndesis/openshift/OpenShiftDeployment.java
@@ -27,6 +27,7 @@ import io.fabric8.kubernetes.client.RequestConfigBuilder;
 @Value.Immutable
 public interface OpenShiftDeployment {
     String getName();
+    Integer getRevisionNumber();
     Optional<Integer> getReplicas();
     Optional<String> getToken();
     Optional<String> getGitRepository();

--- a/openshift/src/main/java/io/syndesis/openshift/OpenShiftService.java
+++ b/openshift/src/main/java/io/syndesis/openshift/OpenShiftService.java
@@ -17,6 +17,8 @@ package io.syndesis.openshift;
 
 public interface OpenShiftService {
 
+    String REVISION_NUMBER_ANNOTATION = "syndesis.io/revision-number";
+
     /**
      * Creates the deployment (Deployment and Build configurations, Image Streams etc)
      * @param d A description of the deployment to create.

--- a/project-generator/src/main/java/io/syndesis/project/converter/GenerateProjectRequest.java
+++ b/project-generator/src/main/java/io/syndesis/project/converter/GenerateProjectRequest.java
@@ -15,22 +15,29 @@
  */
 package io.syndesis.project.converter;
 
-import io.syndesis.model.connection.Connector;
-import io.syndesis.model.integration.Integration;
-
-import org.immutables.value.Value;
-
 import java.util.Map;
+import java.util.Optional;
+
+import io.syndesis.model.connection.Connector;
+import io.syndesis.model.integration.IntegrationRevisionSpec;
+import org.immutables.value.Value;
 
 @Value.Immutable
 public interface GenerateProjectRequest {
+
+    Optional<String> getId();
+    String getName();
+
+    Optional<String> getDescription();
+
+    IntegrationRevisionSpec getSpec();
+
+    Map<String, Connector> getConnectors();
 
     String getGitHubUserLogin();
     String getGitHubUserName();
     String getGitHubUserEmail();
     String getGitHubRepoName();
-    Integration getIntegration();
-    Map<String, Connector> getConnectors();
 
     class Builder extends ImmutableGenerateProjectRequest.Builder {
     }

--- a/project-generator/src/main/java/io/syndesis/project/converter/ProjectGenerator.java
+++ b/project-generator/src/main/java/io/syndesis/project/converter/ProjectGenerator.java
@@ -16,8 +16,6 @@
 package io.syndesis.project.converter;
 
 
-import io.syndesis.model.integration.Integration;
-
 import java.io.IOException;
 import java.util.Map;
 
@@ -26,5 +24,5 @@ public interface ProjectGenerator {
 
     Map<String, byte[]> generate(GenerateProjectRequest request) throws IOException;
 
-    byte[] generatePom(Integration integration) throws IOException;
+    byte[] generatePom(GenerateProjectRequest request) throws IOException;
 }

--- a/project-generator/src/main/resources/io/syndesis/project/converter/templates/README.md.mustache
+++ b/project-generator/src/main/resources/io/syndesis/project/converter/templates/README.md.mustache
@@ -1,6 +1,6 @@
-# {{integration.name}}
+# {{name}}
 
-{{#integration.description}}{{integration.description}}{{/integration.description}}
+{{#description}}{{description}}{{/description}}
 
 ## Running
 

--- a/project-generator/src/main/resources/io/syndesis/project/converter/templates/application.properties.mustache
+++ b/project-generator/src/main/resources/io/syndesis/project/converter/templates/application.properties.mustache
@@ -1,3 +1,3 @@
 ## name of CamelContext
-camel.springboot.name={{integration.name}}
+camel.springboot.name={{name}}
 camel.springboot.streamCachingEnabled = true

--- a/project-generator/src/main/resources/io/syndesis/project/converter/templates/redhat/application.properties.mustache
+++ b/project-generator/src/main/resources/io/syndesis/project/converter/templates/redhat/application.properties.mustache
@@ -1,5 +1,5 @@
 ## name of CamelContext
-camel.springboot.name={{integration.name}}
+camel.springboot.name={{name}}
 camel.springboot.streamCachingEnabled = true
 
 # Binding health checks to an internal port

--- a/project-generator/src/test/java/io/syndesis/project/converter/DefaultProjectGeneratorTest.java
+++ b/project-generator/src/test/java/io/syndesis/project/converter/DefaultProjectGeneratorTest.java
@@ -44,6 +44,7 @@ import io.syndesis.model.filter.ExpressionFilterStep;
 import io.syndesis.model.filter.FilterPredicate;
 import io.syndesis.model.filter.RuleFilterStep;
 import io.syndesis.model.integration.Integration;
+import io.syndesis.model.integration.IntegrationRevisionSpec;
 import io.syndesis.model.integration.SimpleStep;
 import io.syndesis.model.integration.Step;
 import io.syndesis.project.converter.ProjectGeneratorProperties.Templates;
@@ -129,12 +130,13 @@ public class DefaultProjectGeneratorTest {
         GenerateProjectRequest request = new GenerateProjectRequest.Builder()
             .gitHubUserLogin("noob")
             .gitHubRepoName("test")
-            .integration(new Integration.Builder()
-                .id("test-integration")
-                .name("Test Integration")
-                .description("This is a test integration!")
-                .steps( Arrays.asList(step1, step2, step3, step4))
-                .build())
+            .id("test-integration")
+            .name("Test Integration")
+            .description("This is a test integration!")
+                .spec(new IntegrationRevisionSpec.Builder()
+
+                        .steps( Arrays.asList(step1, step2, step3, step4))
+                        .build())
             .connectors(connectors)
             .build();
 
@@ -162,12 +164,12 @@ public class DefaultProjectGeneratorTest {
         Step step2 = new SimpleStep.Builder().stepKind("endpoint").connection(new Connection.Builder().configuredProperties(map()).build()).configuredProperties(map("httpUri", "http://localhost:8080/hello", "username", "admin", "password", "admin", "token", "mytoken")).action(new Action.Builder().connectorId("http").camelConnectorPrefix("http-get").camelConnectorGAV("io.syndesis:http-get-connector:0.4.5").build()).build();
 
         GenerateProjectRequest request = new GenerateProjectRequest.Builder()
-            .integration(new Integration.Builder()
-                .id("test-integration")
-                .name("Test Integration")
-                .description("This is a test integration!")
-                .steps( Arrays.asList(step1, step2))
-                .build())
+            .id("test-integration")
+            .name("Test Integration")
+            .description("This is a test integration!")
+                .spec(new IntegrationRevisionSpec.Builder()
+                    .steps( Arrays.asList(step1, step2))
+                    .build())
             .connectors(connectors)
             .gitHubUserLogin("noob")
             .gitHubRepoName("test")
@@ -188,13 +190,16 @@ public class DefaultProjectGeneratorTest {
 
     @Test
     public void testConvertFromJson() throws Exception {
-
         JsonNode json = new ObjectMapper().readTree(this.getClass().getResourceAsStream("test-integration.json"));
 
+        Integration integration = new ObjectMapper().registerModule(new Jdk8Module()).readValue(json.get("data").toString(), Integration.class);
         GenerateProjectRequest request = new GenerateProjectRequest.Builder()
+            .id(integration.getId().orElse("[none]"))
+            .name(integration.getName())
+            .description(integration.getDescription())
             .gitHubUserLogin("noob")
             .gitHubRepoName("test")
-            .integration(new ObjectMapper().registerModule(new Jdk8Module()).readValue(json.get("data").toString(), Integration.class))
+            .spec(integration.getDraftRevision().get().getSpec())
             .connectors(connectors)
             .build();
 
@@ -252,11 +257,9 @@ public class DefaultProjectGeneratorTest {
         GenerateProjectRequest request = new GenerateProjectRequest.Builder()
             .gitHubUserLogin("noob")
             .gitHubRepoName("test")
-            .integration(new Integration.Builder()
-                .id("test-integration")
-                .name("Test Integration")
-                .steps( Arrays.asList(step1, step2, step3))
-                .build())
+            .id("test-integration")
+            .name("Test Integration")
+            .spec(new IntegrationRevisionSpec.Builder().steps(Arrays.asList(step1, step2, step3)).build())
             .connectors(connectors)
             .build();
 
@@ -288,11 +291,11 @@ public class DefaultProjectGeneratorTest {
         GenerateProjectRequest request = new GenerateProjectRequest.Builder()
             .gitHubUserLogin("noob")
             .gitHubRepoName("test")
-            .integration(new Integration.Builder()
-                .id("test-integration")
-                .name("Test Integration")
-                .steps( Arrays.asList(step1, step2, step3, step4))
-                .build())
+            .id("test-integration")
+            .name("Test Integration")
+            .spec(new IntegrationRevisionSpec.Builder()
+                    .steps( Arrays.asList(step1, step2, step3, step4))
+                    .build())
             .connectors(connectors)
             .build();
 

--- a/project-generator/src/test/java/io/syndesis/project/converter/visitor/RuleFilterStepVisitorTest.java
+++ b/project-generator/src/test/java/io/syndesis/project/converter/visitor/RuleFilterStepVisitorTest.java
@@ -34,7 +34,6 @@ public class RuleFilterStepVisitorTest {
         props.put("rules","[ { \"path\": \"person.name\", \"op\": \"==\", \"value\": \"Ioannis\"}, " +
                           "  { \"path\": \"person.favoriteDrinks\", \"op\": \"contains\", \"value\": \"Gin\" } ]");
         RuleFilterStep step = new RuleFilterStep.Builder()
-            .id("1")
             .configuredProperties(props)
             .build();
 

--- a/project-generator/src/test/resources/io/syndesis/project/converter/test-integration.json
+++ b/project-generator/src/test/resources/io/syndesis/project/converter/test-integration.json
@@ -1,88 +1,87 @@
 {
   "kind": "integration",
   "data": {
-    "configuration": "",
-    "description": "This is an example of a Timed Pull to Post Integration",
     "id": "2",
     "name": "Timed Pull to Post Example",
-    "steps": [
-      {
-        "id": "3",
-        "stepKind": "endpoint",
-        "connection": {
-          "configuredProperties": {},
-          "connectorId": "timer",
-          "description": "Timer Connection",
-          "icon": "fa-globe",
-          "name": "Timer Example",
-          "id": "4"
-        },
-        "action": {
-          "connectorId": "http",
-          "description": "Set a timer that fires at intervals that you specify",
-          "name": "PeriodicTimer",
-          "id": "io.syndesis_timer-connector_@syndesis-connectors.version@",
-          "camelConnectorGAV": "io.syndesis:timer-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "periodic-timer"
-        },
-        "configuredProperties": {
-          "period": "5000"
-        }
-      },
-      {
-        "id": "3",
-        "stepKind": "endpoint",
-        "connection": {
-          "configuredProperties": {},
-          "connectorId": "http",
-          "description": "HTTP Connection",
-          "icon": "fa-globe",
-          "name": "HTTP Example",
-          "id": "3"
-        },
-        "action": {
-          "connectorId": "http",
-          "description": "Call a service that is internal (within your company) or external (on the internet) by specifying the service's URL",
-          "name": "HTTP GET",
-          "id": "io.syndesis:http-get-connector:@syndesis-connectors.version@",
-          "camelConnectorGAV": "io.syndesis:http-get-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "http-get"
-        },
-        "configuredProperties": {
-          "httpUri": "http://localhost:8080/hello"
-        }
-      },
-      {
-        "id": "4",
-        "stepKind": "log",
-        "configuredProperties": {
-          "message": "Hello World! ${body}",
-          "loggingLevel": "INFO"
-        }
-      },
-      {
-        "id": "5",
-        "stepKind": "endpoint",
-        "connection": {
-          "configuredProperties": {},
-          "connectorId": "http",
-          "description": "HTTP Connection",
-          "icon": "fa-globe",
-          "name": "HTTP Example",
-          "id": "3"
-        },
-        "action": {
-          "connectorId": "http",
-          "description": "Call a service that is internal (within your company) or external (on the internet) by specifying the service's URL",
-          "name": "HTTP POST",
-          "id": "io.syndesis:http-post-connector:@syndesis-connectors.version@",
-          "camelConnectorGAV": "io.syndesis:http-post-connector:@syndesis-connectors.version@",
-          "camelConnectorPrefix": "http-post"
-        },
-        "configuredProperties": {
-          "httpUri": "http://localhost:8080/bye"
-        }
+    "description": "This is an example of a Timed Pull to Post Integration",
+    "draftRevision": {
+      "spec": {
+        "steps": [
+          {
+            "stepKind": "endpoint",
+            "connection": {
+              "configuredProperties": {},
+              "connectorId": "timer",
+              "description": "Timer Connection",
+              "icon": "fa-globe",
+              "name": "Timer Example",
+              "id": "4"
+            },
+            "action": {
+              "connectorId": "http",
+              "description": "Set a timer that fires at intervals that you specify",
+              "name": "PeriodicTimer",
+              "id": "io.syndesis_timer-connector_@syndesis-connectors.version@",
+              "camelConnectorGAV": "io.syndesis:timer-connector:@syndesis-connectors.version@",
+              "camelConnectorPrefix": "periodic-timer"
+            },
+            "configuredProperties": {
+              "period": "5000"
+            }
+          },
+          {
+            "stepKind": "endpoint",
+            "connection": {
+              "configuredProperties": {},
+              "connectorId": "http",
+              "description": "HTTP Connection",
+              "icon": "fa-globe",
+              "name": "HTTP Example",
+              "id": "3"
+            },
+            "action": {
+              "connectorId": "http",
+              "description": "Call a service that is internal (within your company) or external (on the internet) by specifying the service's URL",
+              "name": "HTTP GET",
+              "id": "io.syndesis:http-get-connector:@syndesis-connectors.version@",
+              "camelConnectorGAV": "io.syndesis:http-get-connector:@syndesis-connectors.version@",
+              "camelConnectorPrefix": "http-get"
+            },
+            "configuredProperties": {
+              "httpUri": "http://localhost:8080/hello"
+            }
+          },
+          {
+            "stepKind": "log",
+            "configuredProperties": {
+              "message": "Hello World! ${body}",
+              "loggingLevel": "INFO"
+            }
+          },
+          {
+            "stepKind": "endpoint",
+            "connection": {
+              "configuredProperties": {},
+              "connectorId": "http",
+              "description": "HTTP Connection",
+              "icon": "fa-globe",
+              "name": "HTTP Example",
+              "id": "3"
+            },
+            "action": {
+              "connectorId": "http",
+              "description": "Call a service that is internal (within your company) or external (on the internet) by specifying the service's URL",
+              "name": "HTTP POST",
+              "id": "io.syndesis:http-post-connector:@syndesis-connectors.version@",
+              "camelConnectorGAV": "io.syndesis:http-post-connector:@syndesis-connectors.version@",
+              "camelConnectorPrefix": "http-post"
+            },
+            "configuredProperties": {
+              "httpUri": "http://localhost:8080/bye"
+            }
+          }
+        ]
       }
-    ]
+    }
   }
 }

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/integration/IntegrationHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/integration/IntegrationHandler.java
@@ -16,7 +16,6 @@
 package io.syndesis.rest.v1.handler.integration;
 
 import java.math.BigInteger;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;

--- a/rest/src/main/java/io/syndesis/rest/v1/handler/tests/TestSupportHandler.java
+++ b/rest/src/main/java/io/syndesis/rest/v1/handler/tests/TestSupportHandler.java
@@ -91,6 +91,7 @@ public class TestSupportHandler {
         for (Integration i : integrations) {
             OpenShiftDeployment deployment = OpenShiftDeployment
                 .builder()
+                .revisionNumber(i.getDeployedRevisionId().orElse(0))
                 .name(i.getName())
                 .token(Tokens.getAuthenticationToken())
                 .build();

--- a/rest/src/test/java/io/syndesis/rest/v1/handler/IntegrationHandlerTest.java
+++ b/rest/src/test/java/io/syndesis/rest/v1/handler/IntegrationHandlerTest.java
@@ -28,8 +28,10 @@ import io.syndesis.model.connection.ActionDefinition;
 import io.syndesis.model.connection.DataShape;
 import io.syndesis.model.connection.DataShapeKinds;
 import io.syndesis.model.filter.FilterOptions;
-import io.syndesis.model.integration.Integration;
+import io.syndesis.model.integration.IntegrationRevision;
+import io.syndesis.model.integration.IntegrationRevisionSpec;
 import io.syndesis.model.integration.SimpleStep;
+import io.syndesis.model.integration.Step;
 import io.syndesis.rest.v1.handler.integration.IntegrationHandler;
 
 import org.junit.Before;
@@ -60,7 +62,7 @@ public class IntegrationHandlerTest {
     @Test
     public void filterOptionsSimple() {
         when(inspector.getPaths("twitter4j.Status")).thenReturn(Arrays.asList("paramA", "paramB"));
-        Integration integration =
+        IntegrationRevision integration =
             createIntegrationFromDataShapes(dataShape(DataShapeKinds.JAVA, "twitter4j.Status"), null, dataShape(DataShapeKinds.NONE));
 
         FilterOptions options = handler.getFilterOptions(integration, -1);
@@ -71,7 +73,7 @@ public class IntegrationHandlerTest {
     public void filterOptionsMultipleOutputShapes() {
         when(inspector.getPaths("twitter4j.Status")).thenReturn(Arrays.asList("paramA", "paramB"));
         when(inspector.getPaths("blubber.bla")).thenReturn(Arrays.asList("paramY", "paramZ"));
-        Integration integration =
+        IntegrationRevision integration =
             createIntegrationFromDataShapes(dataShape(DataShapeKinds.JAVA, "blubber.bla"),null, dataShape(DataShapeKinds.JAVA, "twitter4j.Status"));
 
         assertThat(handler.getFilterOptions(integration, -1).getPaths())
@@ -83,19 +85,20 @@ public class IntegrationHandlerTest {
 
     @Test
     public void filterOptionsNoOutputShape() {
-        Integration integration =
+        IntegrationRevision integrationRevision =
             createIntegrationFromDataShapes(dataShape(DataShapeKinds.NONE), null);
 
-        FilterOptions options = handler.getFilterOptions(integration, -1);
+        FilterOptions options = handler.getFilterOptions(integrationRevision, -1);
         assertThat(options.getPaths()).isEmpty();
     }
 
-    private Integration createIntegrationFromDataShapes(DataShape... dataShapes) {
-        return new Integration.Builder().steps(steps(dataShapes)).build();
+    private IntegrationRevision createIntegrationFromDataShapes(DataShape... dataShapes) {
+        return new IntegrationRevision.Builder().spec(
+            new IntegrationRevisionSpec.Builder().steps(steps(dataShapes)).build()).build();
     }
 
-    private List<SimpleStep> steps(DataShape ... dataShapes) {
-        List<SimpleStep> ret = new ArrayList<>();
+    private List<Step> steps(DataShape ... dataShapes) {
+        List<Step> ret = new ArrayList<>();
         for (DataShape shape : dataShapes) {
             ActionDefinition.Builder definition = new ActionDefinition.Builder();
             if (shape != null) {

--- a/runtime/src/test/java/io/syndesis/runtime/EventsITCase.java
+++ b/runtime/src/test/java/io/syndesis/runtime/EventsITCase.java
@@ -15,6 +15,12 @@
  */
 package io.syndesis.runtime;
 
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.launchdarkly.eventsource.EventHandler;
 import com.launchdarkly.eventsource.EventSource;
@@ -22,6 +28,10 @@ import com.launchdarkly.eventsource.MessageEvent;
 import io.syndesis.model.ChangeEvent;
 import io.syndesis.model.EventMessage;
 import io.syndesis.model.integration.Integration;
+import io.syndesis.model.integration.IntegrationRevision;
+import io.syndesis.model.integration.IntegrationRevisionSpec;
+import io.syndesis.model.integration.IntegrationRevisionStatus;
+import io.syndesis.model.integration.IntegrationState;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.WebSocket;
@@ -31,13 +41,10 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import java.net.URI;
-import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
-import static io.syndesis.runtime.Recordings.*;
+import static io.syndesis.runtime.Recordings.Invocation;
+import static io.syndesis.runtime.Recordings.recordedInvocations;
+import static io.syndesis.runtime.Recordings.recorder;
+import static io.syndesis.runtime.Recordings.resetRecorderLatch;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -84,9 +91,11 @@ public class EventsITCase extends BaseITCase {
             Integration integration = new Integration.Builder()
                 .id("1001")
                 .name("test")
-                .desiredStatus(Integration.Status.Draft)
-                .currentStatus(Integration.Status.Draft)
-                .build();
+                .draftRevision(new IntegrationRevision.Builder()
+                    .status(new IntegrationRevisionStatus.Builder().state(IntegrationState.Draft).build())
+                    .spec(new IntegrationRevisionSpec.Builder().state(IntegrationState.Draft).build())
+                    .build()
+                ).build();
             post("/api/v1/integrations", integration, Integration.class);
 
             assertThat(countDownLatch.await(1000, TimeUnit.SECONDS)).isTrue();
@@ -179,8 +188,12 @@ public class EventsITCase extends BaseITCase {
         Integration integration = new Integration.Builder()
             .id("1002")
             .name("test")
-            .desiredStatus(Integration.Status.Draft)
-            .currentStatus(Integration.Status.Draft)
+            .draftRevision(
+                new IntegrationRevision.Builder()
+                    .status(new IntegrationRevisionStatus.Builder().state(IntegrationState.Draft).build())
+                    .spec(new IntegrationRevisionSpec.Builder().state(IntegrationState.Draft).build())
+                    .build()
+            )
             .build();
         post("/api/v1/integrations", integration, Integration.class);
 

--- a/runtime/src/test/java/io/syndesis/runtime/IntegrationsITCase.java
+++ b/runtime/src/test/java/io/syndesis/runtime/IntegrationsITCase.java
@@ -19,11 +19,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.JsonNode;
-
 import io.syndesis.model.integration.Integration;
+import io.syndesis.model.integration.IntegrationRevision;
+import io.syndesis.model.integration.IntegrationRevisionSpec;
+import io.syndesis.model.integration.IntegrationRevisionStatus;
+import io.syndesis.model.integration.IntegrationState;
 import io.syndesis.rest.v1.handler.exception.RestError;
 import io.syndesis.rest.v1.operations.Violation;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.http.HttpStatus;
@@ -71,9 +73,12 @@ public class IntegrationsITCase extends BaseITCase {
         Integration integration = new Integration.Builder()
             .id("2001")
             .name("test")
-            .desiredStatus(Integration.Status.Draft)
-            .currentStatus(Integration.Status.Draft)
-            .build();
+            .draftRevision(
+                new IntegrationRevision.Builder()
+                    .status(new IntegrationRevisionStatus.Builder().state(IntegrationState.Draft).build())
+                    .spec(new IntegrationRevisionSpec.Builder().state(IntegrationState.Draft).build())
+                    .build()
+            ).build();
         post("/api/v1/integrations", integration, Integration.class);
 
         // Validate we can now fetch it.
@@ -84,9 +89,12 @@ public class IntegrationsITCase extends BaseITCase {
         integration = new Integration.Builder()
             .id("2002")
             .name("test2")
-            .desiredStatus(Integration.Status.Draft)
-            .currentStatus(Integration.Status.Draft)
-            .build();
+            .draftRevision(
+                new IntegrationRevision.Builder()
+                    .status(new IntegrationRevisionStatus.Builder().state(IntegrationState.Draft).build())
+                    .spec(new IntegrationRevisionSpec.Builder().state(IntegrationState.Draft).build())
+                    .build()
+            ).build();
         post("/api/v1/integrations", integration, Integration.class);
 
         // Check the we can list the integrations.
@@ -124,7 +132,7 @@ public class IntegrationsITCase extends BaseITCase {
 
     @Test
     public void shouldDetermineValidityForValidIntegrations() {
-        final Integration integration = new Integration.Builder().name("Test integration").desiredStatus(Integration.Status.Draft).build();
+        final Integration integration = new Integration.Builder().name("Test integration").build();
 
         final ResponseEntity<List<Violation>> got = post("/api/v1/integrations/validation", integration, RESPONSE_TYPE,
             tokenRule.validToken(), HttpStatus.NO_CONTENT);

--- a/runtime/src/test/java/io/syndesis/runtime/JsonHandlingITCase.java
+++ b/runtime/src/test/java/io/syndesis/runtime/JsonHandlingITCase.java
@@ -44,7 +44,7 @@ public class JsonHandlingITCase extends BaseITCase {
         tags.add("\tTaggy McTagface\t");
 
         final Integration integration = new Integration.Builder().id(id).name("  some-name\t").description("")
-            .tags(tags).desiredStatus(Integration.Status.Draft).build();
+            .tags(tags).build();
         post("/api/v1/integrations", integration, Integration.class);
 
         final ResponseEntity<Integration> result = get("/api/v1/integrations/" + id, Integration.class);

--- a/runtime/src/test/java/io/syndesis/runtime/T3stSupportITCase.java
+++ b/runtime/src/test/java/io/syndesis/runtime/T3stSupportITCase.java
@@ -17,6 +17,10 @@ package io.syndesis.runtime;
 
 import io.syndesis.dao.init.ModelData;
 import io.syndesis.model.integration.Integration;
+import io.syndesis.model.integration.IntegrationRevision;
+import io.syndesis.model.integration.IntegrationRevisionSpec;
+import io.syndesis.model.integration.IntegrationRevisionStatus;
+import io.syndesis.model.integration.IntegrationState;
 import org.junit.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -51,9 +55,12 @@ public class T3stSupportITCase extends BaseITCase {
         Integration integration = new Integration.Builder()
             .id("2001")
             .name("test")
-            .desiredStatus(Integration.Status.Draft)
-            .currentStatus(Integration.Status.Draft)
-            .build();
+            .draftRevision(
+                new IntegrationRevision.Builder()
+                    .status(new IntegrationRevisionStatus.Builder().state(IntegrationState.Draft).build())
+                    .spec(new IntegrationRevisionSpec.Builder().state(IntegrationState.Draft).build())
+                    .build()
+            ).build();
         post("/api/v1/integrations", integration, Integration.class);
 
         // Snapshot should only contain the integration entity..


### PR DESCRIPTION
This work is based on https://github.com/syndesisio/syndesis-rest/pull/493 which has been previously updated with theses changes a week ago, but probably wiped out again with a with a forced push of https://github.com/syndesisio/syndesis-rest/pull/493/commits/7fdec31dd24e0d34dfe757ac61119d2a881e01f6.

An IntegrationRevision (which is part of the Integration) has now a forma
that ressembles that of K8s resources:

```yml 
spec:
  # Desired state
  state: "Published" 
status:
  # Current state
  state: "Draft"
  # Actual version of the revision
  version: 1
  # Message from the last state change
  message: "...."
```

Convenient method the the `curentState` and `desiredState` has been added
as methods to `IntegratioRevision`.

@iocanel @jimmidyson It would be awesome, if we can make some progress here. I will be busy with my talk for JavaZone till Thursday, but it would be awesome if we could have at least a review on this PR till then. I will try to be as responsive as possible.

thanks ...