### PR TITLE
Add a plugin repository for SNAPSHOT 

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -59,6 +59,17 @@
       <url>https://jcenter.bintray.com</url>
     </pluginRepository>
 
+    <pluginRepository>
+      <id>sonatype-snapshot</id>
+      <name>Sonatype snapshot repository</name>
+      <url>https://oss.sonatype.org/service/local/repositories/snapshots/content</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </pluginRepository>
   </pluginRepositories>
 
   <build>


### PR DESCRIPTION
Add a plugin repository for SNAPSHOT, since we are using the ${project.version} for the syndesis plugin.    Error I am getting currently on a mvn clean -

[ERROR] Plugin io.syndesis:syndesis-build-helper-maven-plugin:1.1-SNAPSHOT or one of its dependencies could not be resolved: Could not find artifact io.syndesis:syndesis-build-helper-maven-plugin:jar:1.1-SNAPSHOT in 210final (https://repository.jboss.org/nexus/content/repositories/jboss_releases_staging_profile-8829) -> [Help 1]
